### PR TITLE
[GRO-1908]English invoice language when not polish

### DIFF
--- a/src/Wfirma/WfirmaInvoice.php
+++ b/src/Wfirma/WfirmaInvoice.php
@@ -30,7 +30,7 @@ final class WfirmaInvoice extends Invoice
         $series = $invoice->with('series', '');
         $series->with('id', $this->invoiceSeries->getIdentifier()->toString());
 
-        if ($this->language->isEnglish()) {
+        if (!$this->language->isPolish()) {
             $language = $invoice->with('translation_language', '');
             $language->with('id', '1');
         }

--- a/tests/Unit/Wfirma/WfirmaInvoiceTest.php
+++ b/tests/Unit/Wfirma/WfirmaInvoiceTest.php
@@ -61,11 +61,96 @@ final class WfirmaInvoiceTest extends TestCase
                     new Country('PL')
                 )
             ),
-            new Currency('PLN'),
+            new Currency('USD'),
             new DateTime('2020-02-01'),
             new DateTime('2020-02-01'),
             new DateTime('2020-02-01'),
             new Language('en')
+        );
+
+        self::assertXmlStringEqualsXmlString(
+            <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<api>
+    <invoices>
+        <invoice>
+            <contractor>
+                <id>100</id>
+            </contractor>
+            <paymentmethod>transfer</paymentmethod>
+            <currency>USD</currency>
+            <paid>1</paid>
+            <alreadypaid_initial>0</alreadypaid_initial>
+            <type>normal</type>
+            <price_type>netto</price_type>
+            <date>2020-02-01</date>
+            <paymentdate>2020-02-01</paymentdate>
+            <disposaldate>2020-02-01</disposaldate>
+            <description>Description Example</description>
+            <fullnumber>FV 69/2021</fullnumber>
+            <total>1</total>
+            <series>
+                <id>700</id>
+            </series>
+            <translation_language>
+                <id>1</id>
+            </translation_language>
+            <invoicecontents>
+                <invoicecontent>
+                    <name>item name 1</name>
+                    <unit>szt.</unit>
+                    <count>1</count>
+                    <price>0.1</price>
+                    <vat_code>
+                        <id>1111</id>
+                    </vat_code>
+                </invoicecontent>
+            </invoicecontents>
+            <vat_moss_details>
+                <type>SA</type>
+                <evidence1_type>A</evidence1_type>
+                <evidence2_type>F</evidence2_type>
+            </vat_moss_details>
+        </invoice>
+    </invoices>
+</api>
+XML,
+            $invoice->print(WfirmaMedia::api())->toString()
+        );
+    }
+
+    public function testItPrintsPolish(): void
+    {
+        $invoice = new WfirmaInvoice(
+            new InvoiceIdentifier('1'),
+            new InvoiceSeries(new InvoiceSeriesIdentifier(700)),
+            new InvoiceDescription('Description Example'),
+            new InvoiceFullNumber('FV 99/2021'),
+            new InvoiceTotalValue(100),
+            new WfirmaInvoiceItemCollection([
+                new WfirmaInvoiceItem(
+                    new Name('item name 1'),
+                    new Price(10),
+                    new WfirmaValueAddedTax('1111', new ValueAddedTax(20)),
+                    new NumberOfUnits(1)
+                ),
+            ]),
+            new Person(
+                new ContractorIdentifier('100'),
+                new ContractorName('name'),
+                new ContractorEmail('bar@test.test'),
+                new ContractorAddress(
+                    new Street('name'),
+                    new PostalCode('postal'),
+                    new City('city'),
+                    new Country('PL')
+                )
+            ),
+            new Currency('PLN'),
+            new DateTime('2020-02-01'),
+            new DateTime('2020-02-01'),
+            new DateTime('2020-02-01'),
+            new Language('pl')
         );
 
         self::assertXmlStringEqualsXmlString(
@@ -87,14 +172,11 @@ final class WfirmaInvoiceTest extends TestCase
             <paymentdate>2020-02-01</paymentdate>
             <disposaldate>2020-02-01</disposaldate>
             <description>Description Example</description>
-            <fullnumber>FV 69/2021</fullnumber>
+            <fullnumber>FV 99/2021</fullnumber>
             <total>1</total>
             <series>
                 <id>700</id>
             </series>
-            <translation_language>
-                <id>1</id>
-            </translation_language>
             <invoicecontents>
                 <invoicecontent>
                     <name>item name 1</name>


### PR DESCRIPTION
When invoice language is not polish should be english with polish.