### PR TITLE
Add proper European Union citizen definition

### DIFF
--- a/src/Bookkeeping/Contractor.php
+++ b/src/Bookkeeping/Contractor.php
@@ -7,7 +7,10 @@ use Landingi\BookkeepingBundle\Bookkeeping\Contractor\ContractorIdentifier;
 
 interface Contractor
 {
-    public function getIdentifier(): ContractorIdentifier;
+    /**
+     * This is a representation of a physical person that lives in the European Union.
+     */
     public function isEuropeanUnionCitizen(): bool;
     public function print(Media $media): Media;
+    public function getIdentifier(): ContractorIdentifier;
 }

--- a/src/Bookkeeping/Contractor/Company.php
+++ b/src/Bookkeeping/Contractor/Company.php
@@ -68,6 +68,6 @@ final class Company implements Contractor
 
     public function isEuropeanUnionCitizen(): bool
     {
-        return true;
+        return false;
     }
 }

--- a/src/Bookkeeping/Contractor/Person.php
+++ b/src/Bookkeeping/Contractor/Person.php
@@ -47,6 +47,6 @@ final class Person implements Contractor
 
     public function isEuropeanUnionCitizen(): bool
     {
-        return true;
+        return $this->address->getCountry()->isEuropeanUnion();
     }
 }

--- a/src/Wfirma/Invoice/WfirmaInvoiceBook.php
+++ b/src/Wfirma/Invoice/WfirmaInvoiceBook.php
@@ -57,8 +57,16 @@ final class WfirmaInvoiceBook implements InvoiceBook
         );
     }
 
+    /**
+     * @throws \JsonException
+     * @throws \Landingi\BookkeepingBundle\Bookkeeping\Contractor\ContractorException
+     * @throws \Landingi\BookkeepingBundle\Wfirma\Client\WfirmaClientException
+     * @throws \Landingi\BookkeepingBundle\Wfirma\WfirmaException
+     * @return \Landingi\BookkeepingBundle\Bookkeeping\Invoice
+     */
     public function create(Invoice $invoice): Invoice
     {
+//        dump($invoice->print(WfirmaMedia::api())->toString());die;
         $invoiceResult = $this->getInvoiceResult(
             $this->client->requestPOST(
                 sprintf(

--- a/src/Wfirma/Invoice/WfirmaInvoiceBook.php
+++ b/src/Wfirma/Invoice/WfirmaInvoiceBook.php
@@ -66,7 +66,6 @@ final class WfirmaInvoiceBook implements InvoiceBook
      */
     public function create(Invoice $invoice): Invoice
     {
-//        dump($invoice->print(WfirmaMedia::api())->toString());die;
         $invoiceResult = $this->getInvoiceResult(
             $this->client->requestPOST(
                 sprintf(

--- a/tests/Functional/Wfirma/Invoice/CreateInvoiceTest.php
+++ b/tests/Functional/Wfirma/Invoice/CreateInvoiceTest.php
@@ -58,6 +58,9 @@ final class CreateInvoiceTest extends TestCase
 
     /**
      * Company contractor from EU pays in EUR.
+     *
+     * @see /tests/Functional/payloads/CreateInvoice/contractor.xml
+     * @see /tests/Functional/payloads/CreateInvoice/invoice.xml
      */
     public function testCreateInvoiceCompany(): void
     {
@@ -106,10 +109,7 @@ final class CreateInvoiceTest extends TestCase
 
         self::assertNotEmpty($invoice->getIdentifier()->toString());
 
-        //test find
         $invoice = $this->invoiceBook->find($invoice->getIdentifier());
-
-        //test delete
         $this->invoiceBook->delete($invoice->getIdentifier());
         $this->contractorBook->delete($contractor->getIdentifier());
     }

--- a/tests/Functional/Wfirma/Invoice/CreateInvoiceTest.php
+++ b/tests/Functional/Wfirma/Invoice/CreateInvoiceTest.php
@@ -1,0 +1,117 @@
+<?php
+declare(strict_types=1);
+
+namespace Functional\Wfirma\Invoice;
+
+use DateTime;
+use Landingi\BookkeepingBundle\Bookkeeping\Contractor\Address\City;
+use Landingi\BookkeepingBundle\Bookkeeping\Contractor\Address\Country;
+use Landingi\BookkeepingBundle\Bookkeeping\Contractor\Address\PostalCode;
+use Landingi\BookkeepingBundle\Bookkeeping\Contractor\Address\Street;
+use Landingi\BookkeepingBundle\Bookkeeping\Contractor\Company;
+use Landingi\BookkeepingBundle\Bookkeeping\Contractor\ContractorAddress;
+use Landingi\BookkeepingBundle\Bookkeeping\Contractor\ContractorBook;
+use Landingi\BookkeepingBundle\Bookkeeping\Contractor\ContractorEmail;
+use Landingi\BookkeepingBundle\Bookkeeping\Contractor\ContractorIdentifier;
+use Landingi\BookkeepingBundle\Bookkeeping\Contractor\ContractorName;
+use Landingi\BookkeepingBundle\Bookkeeping\Currency;
+use Landingi\BookkeepingBundle\Bookkeeping\Invoice\InvoiceBook;
+use Landingi\BookkeepingBundle\Bookkeeping\Invoice\InvoiceDescription;
+use Landingi\BookkeepingBundle\Bookkeeping\Invoice\InvoiceFullNumber;
+use Landingi\BookkeepingBundle\Bookkeeping\Invoice\InvoiceIdentifier;
+use Landingi\BookkeepingBundle\Bookkeeping\Invoice\InvoiceItem\Name;
+use Landingi\BookkeepingBundle\Bookkeeping\Invoice\InvoiceItem\NumberOfUnits;
+use Landingi\BookkeepingBundle\Bookkeeping\Invoice\InvoiceItem\Price;
+use Landingi\BookkeepingBundle\Bookkeeping\Invoice\InvoiceItem\ValueAddedTax;
+use Landingi\BookkeepingBundle\Bookkeeping\Invoice\InvoiceSeries;
+use Landingi\BookkeepingBundle\Bookkeeping\Invoice\InvoiceTotalValue;
+use Landingi\BookkeepingBundle\Bookkeeping\Language;
+use Landingi\BookkeepingBundle\Wfirma\Client\Credentials\WfirmaCredentials;
+use Landingi\BookkeepingBundle\Wfirma\Client\WfirmaClient;
+use Landingi\BookkeepingBundle\Wfirma\Contractor\Factory\ContractorFactory;
+use Landingi\BookkeepingBundle\Wfirma\Contractor\WfirmaContractorBook;
+use Landingi\BookkeepingBundle\Wfirma\Invoice\Factory\InvoiceFactory;
+use Landingi\BookkeepingBundle\Wfirma\Invoice\InvoiceItem\WfirmaValueAddedTax;
+use Landingi\BookkeepingBundle\Wfirma\Invoice\WfirmaInvoiceBook;
+use Landingi\BookkeepingBundle\Wfirma\Invoice\WfirmaInvoiceItem;
+use Landingi\BookkeepingBundle\Wfirma\Invoice\WfirmaInvoiceItemCollection;
+use Landingi\BookkeepingBundle\Wfirma\WfirmaInvoice;
+use PHPUnit\Framework\TestCase;
+
+final class CreateInvoiceTest extends TestCase
+{
+    private ContractorBook $contractorBook;
+    private InvoiceBook $invoiceBook;
+
+    public function setUp(): void
+    {
+        $client = new WfirmaClient(
+            new WfirmaCredentials(
+                (string) getenv('WFIRMA_API_LOGIN'),
+                (string) getenv('WFIRMA_API_PASSWORD'),
+                (int) getenv('WFIRMA_API_COMPANY')
+            )
+        );
+
+        $this->invoiceBook = new WfirmaInvoiceBook($client, new InvoiceFactory(), new ContractorFactory());
+        $this->contractorBook = new WfirmaContractorBook($client, new ContractorFactory());
+    }
+
+    /**
+     * Company contractor from EU pays in EUR
+     */
+    public function testCreateInvoiceCompany(): void
+    {
+        //CREATE CONTRACTOR
+        $contractor = $this->contractorBook->create(
+            new Company(
+                new ContractorIdentifier('123'),
+                new ContractorName('EUR FR Company Contractor'),
+                new ContractorEmail('test@landingi.com'),
+                new ContractorAddress(
+                    new Street('Parisian Street'),
+                    new PostalCode('38330'),
+                    new City('Paris'),
+                    new Country('FR')
+                ),
+                new Company\ValueAddedTaxIdentifier('FR50844926014')
+            )
+        );
+
+        self::assertNotEmpty($contractor->getIdentifier()->toString());
+
+        //CREATE INVOICE
+        $invoice = $this->invoiceBook->create(
+            new WfirmaInvoice(
+                new InvoiceIdentifier('123'),
+                new InvoiceSeries(new InvoiceSeries\InvoiceSeriesIdentifier(0)),
+                new InvoiceDescription('test description - bundle invoice'),
+                new InvoiceFullNumber('FV 69/2021'),
+                new InvoiceTotalValue(100),
+                new WfirmaInvoiceItemCollection([
+                    new WfirmaInvoiceItem(
+                        new Name('foo 1'),
+                        new Price((int) (100.55 * 100)),
+                        new WfirmaValueAddedTax(WfirmaValueAddedTax::NO_TAX, new ValueAddedTax(0)),
+                        new NumberOfUnits(2)
+                    ),
+                ]),
+                $contractor,
+                new Currency('EUR'),
+                new DateTime(),
+                new DateTime(),
+                new DateTime(),
+                new Language('PL')
+            )
+        );
+
+        self::assertNotEmpty($invoice->getIdentifier()->toString());
+
+        //test find
+        $invoice = $this->invoiceBook->find($invoice->getIdentifier());
+
+        //test delete
+        $this->invoiceBook->delete($invoice->getIdentifier());
+        $this->contractorBook->delete($contractor->getIdentifier());
+    }
+}

--- a/tests/Functional/Wfirma/Invoice/CreateInvoiceTest.php
+++ b/tests/Functional/Wfirma/Invoice/CreateInvoiceTest.php
@@ -52,13 +52,12 @@ final class CreateInvoiceTest extends TestCase
                 (int) getenv('WFIRMA_API_COMPANY')
             )
         );
-
         $this->invoiceBook = new WfirmaInvoiceBook($client, new InvoiceFactory(), new ContractorFactory());
         $this->contractorBook = new WfirmaContractorBook($client, new ContractorFactory());
     }
 
     /**
-     * Company contractor from EU pays in EUR
+     * Company contractor from EU pays in EUR.
      */
     public function testCreateInvoiceCompany(): void
     {
@@ -74,7 +73,7 @@ final class CreateInvoiceTest extends TestCase
                     new City('Paris'),
                     new Country('FR')
                 ),
-                new Company\ValueAddedTaxIdentifier('FR50844926014')
+                new Company\ValueAddedTaxIdentifier('50844926014')
             )
         );
 

--- a/tests/Functional/Wfirma/Invoice/WfirmaInvoiceBookTest.php
+++ b/tests/Functional/Wfirma/Invoice/WfirmaInvoiceBookTest.php
@@ -52,7 +52,6 @@ final class WfirmaInvoiceBookTest extends TestCase
                 (int) getenv('WFIRMA_API_COMPANY')
             )
         );
-
         $this->invoiceBook = new WfirmaInvoiceBook($client, new InvoiceFactory(), new ContractorFactory());
         $this->contractorBook = new WfirmaContractorBook($client, new ContractorFactory());
     }

--- a/tests/Functional/payloads/CreateInvoice/contractor.xml
+++ b/tests/Functional/payloads/CreateInvoice/contractor.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<api>
+    <contractors>
+        <contractor>
+            <name>EUR FR Company Contractor</name>
+            <altname>EUR FR Company Contractor</altname>
+            <street>Parisian Street</street>
+            <zip>38330</zip>
+            <city>Paris</city>
+            <country>FR</country>
+            <email>test@landingi.com</email>
+            <tax_id_type>vat</tax_id_type>
+            <nip>FR50844926014</nip>
+        </contractor>
+    </contractors>
+</api>

--- a/tests/Functional/payloads/CreateInvoice/invoice.xml
+++ b/tests/Functional/payloads/CreateInvoice/invoice.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<api>
+    <invoices>
+        <invoice>
+            <contractor>
+                <id>57282631</id>
+            </contractor>
+            <paymentmethod>transfer</paymentmethod>
+            <currency>EUR</currency>
+            <paid>1</paid>
+            <alreadypaid_initial>0</alreadypaid_initial>
+            <type>normal</type>
+            <price_type>netto</price_type>
+            <date>2021-06-02</date>
+            <paymentdate>2021-06-02</paymentdate>
+            <disposaldate>2021-06-02</disposaldate>
+            <description>test description - bundle invoice</description>
+            <fullnumber>FV 69/2021</fullnumber>
+            <total>1</total>
+            <series>
+                <id>0</id>
+            </series>
+            <invoicecontents>
+                <invoicecontent>
+                    <name>foo 1</name>
+                    <unit>szt.</unit>
+                    <count>2</count>
+                    <price>100.55</price>
+                    <vat>NP</vat>
+                </invoicecontent>
+            </invoicecontents>
+            <vat_moss_details>
+                <type>SA</type>
+                <evidence1_type>A</evidence1_type>
+                <evidence2_type>F</evidence2_type>
+            </vat_moss_details>
+        </invoice>
+    </invoices>
+</api>

--- a/tests/Unit/Bookkeeping/Contractor/CompanyTest.php
+++ b/tests/Unit/Bookkeeping/Contractor/CompanyTest.php
@@ -32,7 +32,7 @@ final class CompanyTest extends TestCase
             ),
             new ValueAddedTaxIdentifier('id')
         );
-        self::assertTrue($company->isEuropeanUnionCitizen());
+        self::assertFalse($company->isEuropeanUnionCitizen());
     }
 
     public function testItPrintsPolishCompany(): void

--- a/tests/Unit/Bookkeeping/Contractor/PersonTest.php
+++ b/tests/Unit/Bookkeeping/Contractor/PersonTest.php
@@ -31,6 +31,18 @@ final class PersonTest extends TestCase
             )
         );
         self::assertTrue($person->isEuropeanUnionCitizen());
+        $person = new Person(
+            new ContractorIdentifier('id'),
+            new ContractorName('name'),
+            new ContractorEmail('name@foo.bar'),
+            new ContractorAddress(
+                new Street('name'),
+                new PostalCode('postal'),
+                new City('city'),
+                new Country('US')
+            )
+        );
+        self::assertFalse($person->isEuropeanUnionCitizen());
     }
 
     public function testItPrints(): void


### PR DESCRIPTION
Somehow the isEuropeanUnionCitizen checker was hard-coded, but this logic is critical when it comes to VAT codes.

European Union citizen are people living in EU, that does not have NIP or VAT ID (they are not Company)