### PR TITLE
Store value added tax (vat) only for European Union

### DIFF
--- a/src/Bookkeeping/Contractor/Address/Country.php
+++ b/src/Bookkeeping/Contractor/Address/Country.php
@@ -5,6 +5,7 @@ namespace Landingi\BookkeepingBundle\Bookkeeping\Contractor\Address;
 
 use Landingi\BookkeepingBundle\Bookkeeping\Contractor\Exception\AddressException;
 use function in_array;
+use function strlen;
 
 final class Country
 {

--- a/src/Bookkeeping/Contractor/Company.php
+++ b/src/Bookkeeping/Contractor/Company.php
@@ -56,6 +56,14 @@ final class Company implements Contractor
             );
         } else {
             $contractor->with('tax_id_type', 'custom');
+            $contractor->with(
+                'nip',
+                sprintf(
+                    '%s%s',
+                    $this->address->getCountry()->toString(),
+                    $this->valueAddedTaxIdentifier->toString()
+                )
+            );
         }
 
         return $media;

--- a/src/Memory/MemoryValueAddedTaxStorage.php
+++ b/src/Memory/MemoryValueAddedTaxStorage.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Landingi\BookkeepingBundle\Memory;
 
+use Landingi\BookkeepingBundle\Bookkeeping\BookkeepingException;
 use Landingi\BookkeepingBundle\Bookkeeping\Contractor\Address\Country;
 use Landingi\BookkeepingBundle\Bookkeeping\Invoice\InvoiceItem\ValueAddedTax;
 use Landingi\BookkeepingBundle\Bookkeeping\ValueAddedTaxStorage;
@@ -21,7 +22,6 @@ final class MemoryValueAddedTaxStorage implements ValueAddedTaxStorage
         'ES' =>  21,
         'FI' =>  24,
         'FR' =>  20,
-        'GB' =>  20,
         'GR' =>  24,
         'HR' =>  25,
         'HU' =>  27,
@@ -40,8 +40,17 @@ final class MemoryValueAddedTaxStorage implements ValueAddedTaxStorage
         'SE' =>  25,
     ];
 
+    /**
+     * @throws \Landingi\BookkeepingBundle\Bookkeeping\BookkeepingException
+     */
     public function getByCountry(Country $country): ValueAddedTax
     {
+        if (!$country->isEuropeanUnion()) {
+            throw new BookkeepingException(
+                \sprintf('Country %s is outside European Union and is not eligible for VAT', $country->toString())
+            );
+        }
+
         return new ValueAddedTax(self::MEMORY[$country->getAlpha2Code()]);
     }
 }

--- a/tests/Functional/Wfirma/Invoice/CreateInvoiceTest.php
+++ b/tests/Functional/Wfirma/Invoice/CreateInvoiceTest.php
@@ -93,19 +93,19 @@ final class CreateInvoiceTest extends TestCase
         $contractorRequest = <<<XML
 <?xml version="1.0" encoding="UTF-8"?>
 <api>
-   <contractors>
-      <contractor>
-         <name>test foo</name>
-         <altname>test foo</altname>
-         <street>test 123</street>
-         <zip>11-111</zip>
-         <city>test</city>
-         <country>PL</country>
-         <email>test@landingi.com</email>
-         <tax_id_type>nip</tax_id_type>
-         <nip>6482791634</nip>
-      </contractor>
-   </contractors>
+    <contractors>
+        <contractor>
+            <name>test foo</name>
+            <altname>test foo</altname>
+            <street>test 123</street>
+            <zip>11-111</zip>
+            <city>test</city>
+            <country>PL</country>
+            <email>test@landingi.com</email>
+            <tax_id_type>nip</tax_id_type>
+            <nip>6482791634</nip>
+        </contractor>
+    </contractors>
 </api>
 XML;
         self::assertXmlStringEqualsXmlString($contractorRequest, $contractor->print(WfirmaMedia::api())->toString());
@@ -203,19 +203,19 @@ XML;
         $contractorRequest = <<<XML
 <?xml version="1.0" encoding="UTF-8"?>
 <api>
-   <contractors>
-      <contractor>
-         <name>test foo</name>
-         <altname>test foo</altname>
-         <street>test 123</street>
-         <zip>11-111</zip>
-         <city>Paris</city>
-         <country>FR</country>
-         <email>test@landingi.com</email>
-         <tax_id_type>vat</tax_id_type>
-         <nip>FR50844926014</nip>
-      </contractor>
-   </contractors>
+    <contractors>
+        <contractor>
+            <name>test foo</name>
+            <altname>test foo</altname>
+            <street>test 123</street>
+            <zip>11-111</zip>
+            <city>Paris</city>
+            <country>FR</country>
+            <email>test@landingi.com</email>
+            <tax_id_type>vat</tax_id_type>
+            <nip>FR50844926014</nip>
+        </contractor>
+    </contractors>
 </api>
 XML;
         self::assertXmlStringEqualsXmlString($contractorRequest, $contractor->print(WfirmaMedia::api())->toString());

--- a/tests/Functional/Wfirma/Invoice/CreateInvoiceTest.php
+++ b/tests/Functional/Wfirma/Invoice/CreateInvoiceTest.php
@@ -426,13 +426,15 @@ XML;
 <api>
     <contractors>
         <contractor>
-             <name>test foo</name>
-             <altname>test foo</altname>
-             <street>test 123</street>
-             <zip>11-111</zip>
-             <city>New York</city>
-             <country>US</country>
-             <email>test@landingi.com</email>
+            <name>test foo</name>
+            <altname>test foo</altname>
+            <street>test 123</street>
+            <zip>11-111</zip>
+            <city>New York</city>
+            <country>US</country>
+            <email>test@landingi.com</email>
+            <tax_id_type>custom</tax_id_type>
+            <nip>US333444555</nip>
         </contractor>
     </contractors>
 </api>

--- a/tests/Functional/Wfirma/Invoice/CreateInvoiceTest.php
+++ b/tests/Functional/Wfirma/Invoice/CreateInvoiceTest.php
@@ -246,42 +246,42 @@ XML;
         $invoiceRequest = <<<XML
 <?xml version="1.0" encoding="UTF-8"?>
 <api>
-   <invoices>
-      <invoice>
-         <contractor>
-            <id>{$contractor->getIdentifier()->toString()}</id>
-         </contractor>
-         <paymentmethod>transfer</paymentmethod>
-         <currency>EUR</currency>
-         <paid>1</paid>
-         <alreadypaid_initial>0</alreadypaid_initial>
-         <type>normal</type>
-         <price_type>netto</price_type>
-         <date>{$this->today->format('Y-m-d')}</date>
-         <paymentdate>{$this->today->format('Y-m-d')}</paymentdate>
-         <disposaldate>{$this->today->format('Y-m-d')}</disposaldate>
-         <description>testCompanyInEuropeanUnion</description>
-         <fullnumber>{$invoice->getFullNumber()->toString()}</fullnumber>
-         <total>201.1</total>
-         <series>
-            <id>2539307</id>
-         </series>
-         <translation_language>
-            <id>1</id>
-         </translation_language>
-         <invoicecontents>
-            <invoicecontent>
-               <name>foo 1</name>
-               <unit>szt.</unit>
-               <count>2</count>
-               <price>100.55</price>
-               <vat_code>
-                   <id>230</id>
-               </vat_code>
-            </invoicecontent>
-         </invoicecontents>
-      </invoice>
-   </invoices>
+    <invoices>
+        <invoice>
+            <contractor>
+                <id>{$contractor->getIdentifier()->toString()}</id>
+            </contractor>
+            <paymentmethod>transfer</paymentmethod>
+            <currency>EUR</currency>
+            <paid>1</paid>
+            <alreadypaid_initial>0</alreadypaid_initial>
+            <type>normal</type>
+            <price_type>netto</price_type>
+            <date>{$this->today->format('Y-m-d')}</date>
+            <paymentdate>{$this->today->format('Y-m-d')}</paymentdate>
+            <disposaldate>{$this->today->format('Y-m-d')}</disposaldate>
+            <description>testCompanyInEuropeanUnion</description>
+            <fullnumber>{$invoice->getFullNumber()->toString()}</fullnumber>
+            <total>201.1</total>
+            <series>
+                <id>2539307</id>
+            </series>
+            <translation_language>
+                <id>1</id>
+            </translation_language>
+            <invoicecontents>
+                <invoicecontent>
+                    <name>foo 1</name>
+                    <unit>szt.</unit>
+                    <count>2</count>
+                    <price>100.55</price>
+                    <vat_code>
+                        <id>230</id>
+                    </vat_code>
+                </invoicecontent>
+            </invoicecontents>
+        </invoice>
+    </invoices>
 </api>
 XML;
         self::assertXmlStringEqualsXmlString($invoiceRequest, $invoice->print(WfirmaMedia::api())->toString());
@@ -313,19 +313,19 @@ XML;
         $contractorRequest = <<<XML
 <?xml version="1.0" encoding="UTF-8"?>
 <api>
-   <contractors>
-      <contractor>
-         <name>test foo</name>
-         <altname>test foo</altname>
-         <street>test 123</street>
-         <zip>11-111</zip>
-         <city>London</city>
-         <country>GB</country>
-         <email>test@landingi.com</email>
-         <tax_id_type>custom</tax_id_type>
-         <nip>GB50844926014</nip>
-      </contractor>
-   </contractors>
+    <contractors>
+        <contractor>
+            <name>test foo</name>
+            <altname>test foo</altname>
+            <street>test 123</street>
+            <zip>11-111</zip>
+            <city>London</city>
+            <country>GB</country>
+            <email>test@landingi.com</email>
+            <tax_id_type>custom</tax_id_type>
+            <nip>GB50844926014</nip>
+        </contractor>
+    </contractors>
 </api>
 XML;
         self::assertXmlStringEqualsXmlString($contractorRequest, $contractor->print(WfirmaMedia::api())->toString());

--- a/tests/Functional/Wfirma/WfirmaClientTest.php
+++ b/tests/Functional/Wfirma/WfirmaClientTest.php
@@ -44,7 +44,6 @@ final class WfirmaClientTest extends TestCase
         yield ['ES', 21];
         yield ['FI', 24];
         yield ['FR', 20];
-        yield ['GB', 20];
         yield ['GR', 24];
         yield ['HR', 25];
         yield ['HU', 27];

--- a/tests/Unit/Bookkeeping/Contractor/CompanyTest.php
+++ b/tests/Unit/Bookkeeping/Contractor/CompanyTest.php
@@ -170,6 +170,7 @@ XML,
             <country>UY</country>
             <email>name@foo.bar</email>
             <tax_id_type>custom</tax_id_type>
+            <nip>UY333444555</nip>
         </contractor>
     </contractors>
 </api>

--- a/tests/Unit/Memory/MemoryValueAddedTaxStorageTest.php
+++ b/tests/Unit/Memory/MemoryValueAddedTaxStorageTest.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Landingi\BookkeepingBundle\Unit\Memory;
 
+use Landingi\BookkeepingBundle\Bookkeeping\BookkeepingException;
 use Landingi\BookkeepingBundle\Bookkeeping\Contractor\Address\Country;
 use Landingi\BookkeepingBundle\Memory\MemoryValueAddedTaxStorage;
 use PHPUnit\Framework\TestCase;
@@ -19,5 +20,51 @@ final class MemoryValueAddedTaxStorageTest extends TestCase
     public function testItGetsValueAddedTaxByCountry(): void
     {
         self::assertEquals(23, $this->storage->getByCountry(new Country('PL'))->getRate());
+    }
+
+    public function testGreatBritainIsOutsideEuropeanUnion(): void
+    {
+        $this->expectException(BookkeepingException::class);
+        $this->expectExceptionMessage('Country GB is outside European Union and is not eligible for VAT');
+        $this->storage->getByCountry(new Country('GB'));
+    }
+
+    /**
+     * @dataProvider getEuropeanUnionCountriesValueAddedTaxRate
+     */
+    public function testItHasOnlyValueAddedTaxForEuropeanUnionCountries(string $country, int $tax): void
+    {
+        self::assertEquals($tax, $this->storage->getByCountry(new Country($country))->getRate());
+    }
+
+    public function getEuropeanUnionCountriesValueAddedTaxRate(): \Generator
+    {
+        yield ['AT', 20];
+        yield ['BE', 21];
+        yield ['BG', 20];
+        yield ['CY', 19];
+        yield ['CZ', 21];
+        yield ['DE', 19];
+        yield ['DK', 25];
+        yield ['EE', 20];
+        yield ['ES', 21];
+        yield ['FI', 24];
+        yield ['FR', 20];
+        yield ['GR', 24];
+        yield ['HR', 25];
+        yield ['HU', 27];
+        yield ['IE', 23];
+        yield ['IT', 22];
+        yield ['LT', 21];
+        yield ['LV', 21];
+        yield ['LU', 17];
+        yield ['MT', 18];
+        yield ['NL', 21];
+        yield ['PL', 23];
+        yield ['PT', 23];
+        yield ['RO', 19];
+        yield ['SK', 20];
+        yield ['SI', 22];
+        yield ['SE', 25];
     }
 }


### PR DESCRIPTION
* The `tax_id_type` parameter in case 1.3 should be sent
* Validate if the Country actually is from the EU when asking for VAT tax
* Spacing improvements