### PR TITLE
Create tests for Wfirma VAT identifier

### DIFF
--- a/src/Wfirma/Client/WfirmaClient.php
+++ b/src/Wfirma/Client/WfirmaClient.php
@@ -51,6 +51,10 @@ final class WfirmaClient
         return $this->handleResponse(json_decode($this->getCurl($url)->requestDELETE(), true, 512, JSON_THROW_ON_ERROR), $url);
     }
 
+    /**
+     * @throws \JsonException
+     * @throws \Landingi\BookkeepingBundle\Wfirma\Client\WfirmaClientException
+     */
     public function getVatId(string $countryCode, int $vatRate): int
     {
         /**
@@ -64,6 +68,16 @@ final class WfirmaClient
             'declaration_countries/find',
             (string) (new Request\DeclarationCountries\Find($countryCode))
         );
+
+        if (empty($country['declaration_countries'])) {
+            throw new WfirmaClientException(
+                'declaration_countries/find',
+                $country,
+                'declaration_countries',
+                'Declaration Country not found'
+            );
+        }
+
         $vatCode = $this->requestPOST(
             'vat_codes/find',
             (string) (new Request\VatCodes\Find(
@@ -71,6 +85,15 @@ final class WfirmaClient
                 $vatRate
             ))
         );
+
+        if (empty($vatCode['vat_codes'])) {
+            throw new WfirmaClientException(
+                'vat_codes/find',
+                $vatCode,
+                'vat_codes',
+                'Vat Code Not Found'
+            );
+        }
 
         return (int) $vatCode['vat_codes'][0]['vat_code']['id'];
     }

--- a/src/Wfirma/Client/WfirmaClient.php
+++ b/src/Wfirma/Client/WfirmaClient.php
@@ -69,7 +69,7 @@ final class WfirmaClient
             (string) (new Request\DeclarationCountries\Find($countryCode))
         );
 
-        if (empty($country['declaration_countries'])) {
+        if (empty($country['declaration_countries'][0])) {
             throw new WfirmaClientException(
                 'declaration_countries/find',
                 $country,
@@ -86,7 +86,7 @@ final class WfirmaClient
             ))
         );
 
-        if (empty($vatCode['vat_codes'])) {
+        if (empty($vatCode['vat_codes'][0])) {
             throw new WfirmaClientException(
                 'vat_codes/find',
                 $vatCode,

--- a/tests/Functional/Wfirma/WfirmaClientTest.php
+++ b/tests/Functional/Wfirma/WfirmaClientTest.php
@@ -32,7 +32,7 @@ final class WfirmaClientTest extends TestCase
     public function testItDoesNotFindValueAddedTaxRate(): void
     {
         $this->expectException(WfirmaClientException::class);
-        $this->client->getVatId('PL', 999);
+        $this->client->getVatId('DE', 999);
     }
 
     /**

--- a/tests/Functional/Wfirma/WfirmaClientTest.php
+++ b/tests/Functional/Wfirma/WfirmaClientTest.php
@@ -5,6 +5,7 @@ namespace Functional\Wfirma;
 
 use Landingi\BookkeepingBundle\Wfirma\Client\Credentials\WfirmaCredentials;
 use Landingi\BookkeepingBundle\Wfirma\Client\WfirmaClient;
+use Landingi\BookkeepingBundle\Wfirma\Client\WfirmaClientException;
 use PHPUnit\Framework\TestCase;
 
 final class WfirmaClientTest extends TestCase
@@ -20,6 +21,18 @@ final class WfirmaClientTest extends TestCase
                 (int) getenv('WFIRMA_API_COMPANY')
             )
         );
+    }
+
+    public function testItDoesNotFindCountry(): void
+    {
+        $this->expectException(WfirmaClientException::class);
+        $this->client->getVatId('ZZ', 0);
+    }
+
+    public function testItDoesNotFindValueAddedTaxRate(): void
+    {
+        $this->expectException(WfirmaClientException::class);
+        $this->client->getVatId('PL', 999);
     }
 
     /**


### PR DESCRIPTION
Throw exception if Wfirma will respond with some sort of empty response, as empty responses look like this:

```
{
    "vat_codes": {
        "parameters": {
            "limit": "20",
            "page": "1",
            "total": "0"
        }
    },
    "status": {
        "code": "OK"
    }
}
```