### PR TITLE
[PI-1123]invoice not found exception handler added

### DIFF
--- a/src/Wfirma/Client/WfirmaClient.php
+++ b/src/Wfirma/Client/WfirmaClient.php
@@ -109,7 +109,7 @@ final class WfirmaClient
             throw new WfirmaClientException($url, [$result], 'invoice_download', 'Invalid response');
         }
 
-        return $result;
+        return $this->handleFileResponse($result, $url, 'invoice_download');
     }
 
     private function getCurl(string $url): Curl
@@ -147,5 +147,20 @@ final class WfirmaClient
             default:
                 throw new FatalException($url, $result, $data);
         }
+    }
+
+    /**
+     * @throws NotFoundException
+     * @throws WfirmaClientException
+     */
+    private function handleFileResponse(string $result, string $url, string $data = ''): string
+    {
+        if (null !== $jsonResult = json_decode($result, true)) {
+            if ('ERROR' === $jsonResult['status']['code']) {
+                throw new NotFoundException($url, [$result], $data);
+            }
+        }
+
+        return $result;
     }
 }

--- a/src/Wfirma/Client/WfirmaClient.php
+++ b/src/Wfirma/Client/WfirmaClient.php
@@ -163,12 +163,11 @@ final class WfirmaClient
     }
 
     /**
-     * @throws \JsonException
      * @throws \Landingi\BookkeepingBundle\Wfirma\Client\Exception\NotFoundException
      */
     private function handleFileResponse(string $result, string $url, string $data = ''): string
     {
-        $jsonResult = json_decode($result, true, 512, JSON_THROW_ON_ERROR);
+        $jsonResult = json_decode($result, true);
 
         if (null !== $jsonResult && 'ERROR' === $jsonResult['status']['code']) {
             throw new NotFoundException($url, [$result], $data);

--- a/src/Wfirma/Client/WfirmaClient.php
+++ b/src/Wfirma/Client/WfirmaClient.php
@@ -10,6 +10,7 @@ use Landingi\BookkeepingBundle\Wfirma\Client\Exception\FatalException;
 use Landingi\BookkeepingBundle\Wfirma\Client\Exception\NotFoundException;
 use Landingi\BookkeepingBundle\Wfirma\Client\Exception\OutOfServiceException;
 use Landingi\BookkeepingBundle\Wfirma\Client\Request\Invoice\Download;
+use function json_decode;
 use function sprintf;
 
 final class WfirmaClient

--- a/tests/Functional/Wfirma/Invoice/DownloadInvoiceTest.php
+++ b/tests/Functional/Wfirma/Invoice/DownloadInvoiceTest.php
@@ -30,6 +30,7 @@ use Landingi\BookkeepingBundle\Bookkeeping\Invoice\InvoiceTotalValue;
 use Landingi\BookkeepingBundle\Bookkeeping\Language;
 use Landingi\BookkeepingBundle\Memory\Contractor\Company\ValueAddedTax\MemoryIdentifierFactory;
 use Landingi\BookkeepingBundle\Wfirma\Client\Credentials\WfirmaCredentials;
+use Landingi\BookkeepingBundle\Wfirma\Client\Exception\NotFoundException;
 use Landingi\BookkeepingBundle\Wfirma\Client\WfirmaClient;
 use Landingi\BookkeepingBundle\Wfirma\Contractor\Factory\ContractorFactory;
 use Landingi\BookkeepingBundle\Wfirma\Contractor\WfirmaContractorBook;
@@ -113,6 +114,15 @@ class DownloadInvoiceTest extends TestCase
         $this->assertIsString($invoiceFile);
 
         $this->cleanUp($invoice, $contractor);
+    }
+
+    public function testItFailsOnDownloadFile(): void
+    {
+        // Arrange
+        $this->expectException(NotFoundException::class);
+
+        // Act
+        $this->invoiceBook->download(new InvoiceIdentifier('1'));
     }
 
     private function cleanUp(Invoice $invoice, Contractor $contractor): void


### PR DESCRIPTION
Thanks to this code when Wfirma responses with JSON error message after download invoice request, file response handler will throw not found exception. This situation is related to case that invoice identifier sent to Wfirma is invalid or it is problem with fetching invoice file from their server.