### PR TITLE
Trigger CI pipeline only on push

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
     ci:


### PR DESCRIPTION
The pull_request option created many problems with Ci as 4 jobs were executed.