### PR TITLE
Convert all applicable characters to HTML entities in XML value

### DIFF
--- a/src/Wfirma/WfirmaMedia.php
+++ b/src/Wfirma/WfirmaMedia.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Landingi\BookkeepingBundle\Wfirma;
 
+use Exception;
 use Landingi\BookkeepingBundle\Bookkeeping\Media;
 use RuntimeException;
 use SimpleXMLElement;
@@ -31,13 +32,17 @@ XML
 
     public function with(string $key, string $value): self
     {
-        if ('' === $value) {
-            $child = $this->builder->addChild($key);
-        } else {
-            $child = $this->builder->addChild($key, $value);
-        }
+        try {
+            if ('' === $value) {
+                $child = $this->builder->addChild($key);
+            } else {
+                $child = $this->builder->addChild($key, htmlentities($value));
+            }
 
-        return new self($child);
+            return new self($child);
+        } catch (Exception $e) {
+            throw new RuntimeException('Invalid XML child value');
+        }
     }
 
     public function toString(): string

--- a/tests/Functional/Wfirma/Contractor/Resources/companies.json
+++ b/tests/Functional/Wfirma/Contractor/Resources/companies.json
@@ -29,6 +29,16 @@
             "city": "New York",
             "country": "US",
             "nip": "600500300"
+        },
+        {
+            "id": "1234",
+            "name": "World & Universe Company",
+            "email": "world.company@gmail.com",
+            "street": "Wall Street",
+            "zip": "53008",
+            "city": "New York",
+            "country": "US",
+            "nip": "600500300"
         }
     ]
 }

--- a/tests/Functional/Wfirma/Contractor/Resources/companies.json
+++ b/tests/Functional/Wfirma/Contractor/Resources/companies.json
@@ -29,16 +29,6 @@
             "city": "New York",
             "country": "US",
             "nip": "600500300"
-        },
-        {
-            "id": "1234",
-            "name": "World & Universe Company",
-            "email": "world.company@gmail.com",
-            "street": "Wall Street",
-            "zip": "53008",
-            "city": "New York",
-            "country": "US",
-            "nip": "600500300"
         }
     ]
 }

--- a/tests/Unit/Wfirma/WfirmaMediaTest.php
+++ b/tests/Unit/Wfirma/WfirmaMediaTest.php
@@ -32,6 +32,7 @@ XML;
         $this->media->with('child', 'value');
         $this->media->with('child', '')->with('child', 'value');
         $this->media->with('child', '');
+        $this->media->with('child', 'Company & World');
 
         self::assertXmlStringEqualsXmlString(
             <<<XML
@@ -42,6 +43,7 @@ XML;
         <child>value</child>    
     </child>
     <child></child>
+    <child>Company &amp; World</child>
 </root>
 XML,
             $this->media->toString()


### PR DESCRIPTION
We found out that many companies have special characters in their name, yet some of them are not available to use in XML standards. That's why we have to convert these characters to entities.