### PR TITLE
Do not encode language dialect characters - just the XML sensitive

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
     bookkeeping-bundle:
-        image: ferror/symfony-image:7.4
+        image: ferror/symfony-image:8.0
         command: ["make", "run"]
         volumes:
             - ./:/app:delegated

--- a/src/Wfirma/WfirmaMedia.php
+++ b/src/Wfirma/WfirmaMedia.php
@@ -36,7 +36,7 @@ XML
             if ('' === $value) {
                 $child = $this->builder->addChild($key);
             } else {
-                $child = $this->builder->addChild($key, htmlspecialchars($value));
+                $child = $this->builder->addChild($key, htmlspecialchars($value, ENT_XML1, 'UTF-8'));
             }
 
             return new self($child);

--- a/src/Wfirma/WfirmaMedia.php
+++ b/src/Wfirma/WfirmaMedia.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Landingi\BookkeepingBundle\Wfirma;
 
+use Error;
 use Exception;
 use Landingi\BookkeepingBundle\Bookkeeping\Media;
 use RuntimeException;
@@ -40,7 +41,7 @@ XML
             }
 
             return new self($child);
-        } catch (Exception $e) {
+        } catch (Exception | Error $e) {
             throw new RuntimeException('Invalid XML child value');
         }
     }

--- a/src/Wfirma/WfirmaMedia.php
+++ b/src/Wfirma/WfirmaMedia.php
@@ -36,7 +36,7 @@ XML
             if ('' === $value) {
                 $child = $this->builder->addChild($key);
             } else {
-                $child = $this->builder->addChild($key, htmlentities($value));
+                $child = $this->builder->addChild($key, htmlspecialchars($value));
             }
 
             return new self($child);

--- a/src/Wfirma/WfirmaMedia.php
+++ b/src/Wfirma/WfirmaMedia.php
@@ -36,7 +36,7 @@ XML
             if ('' === $value) {
                 $child = $this->builder->addChild($key);
             } else {
-                $child = $this->builder->addChild($key, htmlspecialchars($value, ENT_XML1, 'UTF-8'));
+                $child = $this->builder->addChild($key, htmlspecialchars($value, ENT_COMPAT, 'UTF-8'));
             }
 
             return new self($child);

--- a/tests/Functional/Wfirma/Contractor/Resources/people.json
+++ b/tests/Functional/Wfirma/Contractor/Resources/people.json
@@ -32,7 +32,7 @@
             "name": "Grzegorz Brzęczyszczykiewicz",
             "email": "polish.person@gmail.com",
             "street": "Kręta",
-            "zip": "53008",
+            "zip": "53-008",
             "city": "Tarnowskie Góry",
             "country": "PL"
         }

--- a/tests/Functional/Wfirma/Contractor/Resources/people.json
+++ b/tests/Functional/Wfirma/Contractor/Resources/people.json
@@ -26,6 +26,15 @@
             "zip": "53008",
             "city": "New York",
             "country": "US"
+        },
+        {
+            "id": "1234",
+            "name": "Grzegorz Brzęczyszczykiewicz",
+            "email": "polish.person@gmail.com",
+            "street": "Kręta",
+            "zip": "53008",
+            "city": "Tarnowskie Góry",
+            "country": "PL"
         }
     ]
 }

--- a/tests/Unit/Wfirma/WfirmaMediaTest.php
+++ b/tests/Unit/Wfirma/WfirmaMediaTest.php
@@ -5,6 +5,7 @@ namespace Landingi\BookkeepingBundle\Unit\Wfirma;
 
 use Landingi\BookkeepingBundle\Wfirma\WfirmaMedia;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 use SimpleXMLElement;
 
 final class WfirmaMediaTest extends TestCase
@@ -48,5 +49,11 @@ XML;
 XML,
             $this->media->toString()
         );
+    }
+
+    public function testItThrowsException(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->media->with('', '');
     }
 }


### PR DESCRIPTION
At first, i decided to use `htmlentities` PHP function to escape & and other characters that do not suit XML. Yet after a while, we encountered an error that Wfirma defines our request as invalid when polish or any dialect characters are present.

```php
htmlentities('ó'); //&oacute;
```

Therefore to maintain the usability of wfirma API we have to preserve dialect characters and escape other invalid characters.