### PR TITLE
[BUG-467]Handle Invalid Tax ID for created Contractor

### DIFF
--- a/src/Vies/Contractor/Company/ValueAddedTax/ViesIdentifierFactory.php
+++ b/src/Vies/Contractor/Company/ValueAddedTax/ViesIdentifierFactory.php
@@ -28,6 +28,10 @@ final class ViesIdentifierFactory implements IdentifierFactory
     {
         try {
             $validation = $this->vies->validateVat($country, $identifier);
+
+            if (false === $validation->isValid()) {
+                throw new Exception('Invalid Tax Id');
+            }
         } catch (Exception $e) {
             throw new ViesException('VIES external service exception: ' . $e->getMessage());
         }

--- a/src/Vies/Contractor/Company/ValueAddedTax/ViesIdentifierFactory.php
+++ b/src/Vies/Contractor/Company/ValueAddedTax/ViesIdentifierFactory.php
@@ -32,11 +32,7 @@ final class ViesIdentifierFactory implements IdentifierFactory
             if (false === $validation->isValid()) {
                 throw new Exception('Invalid Tax Id');
             }
-        } catch (Exception $e) {
-            throw new ViesException('VIES external service exception: ' . $e->getMessage());
-        }
 
-        if ($validation->isValid()) {
             $country = new Country($country);
 
             if ($country->isPoland()) {
@@ -44,8 +40,8 @@ final class ViesIdentifierFactory implements IdentifierFactory
             }
 
             return new ValidatedIdentifier(new SimpleIdentifier($identifier), $country);
+        } catch (Exception $e) {
+            throw new ViesException('VIES external service exception: ' . $e->getMessage());
         }
-
-        return new SimpleIdentifier($identifier);
     }
 }

--- a/src/Vies/Contractor/Company/ValueAddedTax/ViesIdentifierFactory.php
+++ b/src/Vies/Contractor/Company/ValueAddedTax/ViesIdentifierFactory.php
@@ -10,6 +10,7 @@ use Landingi\BookkeepingBundle\Bookkeeping\Contractor\Company\ValueAddedTax\Iden
 use Landingi\BookkeepingBundle\Bookkeeping\Contractor\Company\ValueAddedTax\SimpleIdentifier;
 use Landingi\BookkeepingBundle\Bookkeeping\Contractor\Company\ValueAddedTax\ValidatedIdentifier;
 use Landingi\BookkeepingBundle\Bookkeeping\Contractor\Company\ValueAddedTaxIdentifier;
+use Landingi\BookkeepingBundle\Vies\Contractor\InvalidViesIdentifierException;
 use Landingi\BookkeepingBundle\Vies\ViesException;
 
 final class ViesIdentifierFactory implements IdentifierFactory
@@ -22,7 +23,7 @@ final class ViesIdentifierFactory implements IdentifierFactory
     }
 
     /**
-     * @throws \Landingi\BookkeepingBundle\Vies\ViesException
+     * @throws ViesException
      */
     public function create(string $identifier, string $country): ValueAddedTaxIdentifier
     {
@@ -30,7 +31,7 @@ final class ViesIdentifierFactory implements IdentifierFactory
             $validation = $this->vies->validateVat($country, $identifier);
 
             if (false === $validation->isValid()) {
-                throw new Exception('Invalid Tax Id');
+                throw InvalidViesIdentifierException::validationFailed($identifier);
             }
 
             $country = new Country($country);

--- a/src/Vies/Contractor/Company/ValueAddedTax/ViesIdentifierFactory.php
+++ b/src/Vies/Contractor/Company/ValueAddedTax/ViesIdentifierFactory.php
@@ -32,7 +32,11 @@ final class ViesIdentifierFactory implements IdentifierFactory
             if (false === $validation->isValid()) {
                 throw new Exception('Invalid Tax Id');
             }
+        } catch (Exception $e) {
+            throw new ViesException('VIES external service exception: ' . $e->getMessage());
+        }
 
+        if ($validation->isValid()) {
             $country = new Country($country);
 
             if ($country->isPoland()) {
@@ -40,8 +44,8 @@ final class ViesIdentifierFactory implements IdentifierFactory
             }
 
             return new ValidatedIdentifier(new SimpleIdentifier($identifier), $country);
-        } catch (Exception $e) {
-            throw new ViesException('VIES external service exception: ' . $e->getMessage());
         }
+
+        return new SimpleIdentifier($identifier);
     }
 }

--- a/src/Vies/Contractor/InvalidViesIdentifierException.php
+++ b/src/Vies/Contractor/InvalidViesIdentifierException.php
@@ -10,6 +10,6 @@ final class InvalidViesIdentifierException extends Exception
 {
     public static function validationFailed(string $identifier): self
     {
-        return new self(sprintf("Identifier %s is invalid", $identifier));
+        return new self(sprintf('Identifier %s is invalid', $identifier));
     }
 }

--- a/src/Vies/Contractor/InvalidViesIdentifierException.php
+++ b/src/Vies/Contractor/InvalidViesIdentifierException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Landingi\BookkeepingBundle\Vies\Contractor;
+
+use Exception;
+
+final class InvalidViesIdentifierException extends Exception
+{
+    public static function validationFailed(string $identifier): self
+    {
+        return new self(sprintf("Identifier %s is invalid", $identifier));
+    }
+}

--- a/tests/Functional/Vies/ViesValueAddedTaxIdentifierFactoryTest.php
+++ b/tests/Functional/Vies/ViesValueAddedTaxIdentifierFactoryTest.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 namespace Landingi\BookkeepingBundle\Functional\Vies;
 
 use DragonBe\Vies\Vies;
-use Exception;
 use Landingi\BookkeepingBundle\Bookkeeping\Contractor\Company\ValueAddedTax\SimpleIdentifier;
 use Landingi\BookkeepingBundle\Bookkeeping\Contractor\Company\ValueAddedTax\ValidatedIdentifier;
 use Landingi\BookkeepingBundle\Vies\Contractor\Company\ValueAddedTax\ViesIdentifierFactory;
+use Landingi\BookkeepingBundle\Vies\ViesException;
 use PHPUnit\Framework\TestCase;
 
 final class ViesValueAddedTaxIdentifierFactoryTest extends TestCase
@@ -35,6 +35,6 @@ final class ViesValueAddedTaxIdentifierFactoryTest extends TestCase
         $factory = new ViesIdentifierFactory(new Vies());
         $factory->create('333111222', 'DE');
 
-        self::expectException(Exception::class);
+        self::expectException(ViesException::class);
     }
 }

--- a/tests/Functional/Vies/ViesValueAddedTaxIdentifierFactoryTest.php
+++ b/tests/Functional/Vies/ViesValueAddedTaxIdentifierFactoryTest.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 namespace Landingi\BookkeepingBundle\Functional\Vies;
 
 use DragonBe\Vies\Vies;
+use Exception;
+use Landingi\BookkeepingBundle\Bookkeeping\Contractor\Company\ValueAddedTax\SimpleIdentifier;
+use Landingi\BookkeepingBundle\Bookkeeping\Contractor\Company\ValueAddedTax\ValidatedIdentifier;
 use Landingi\BookkeepingBundle\Vies\Contractor\Company\ValueAddedTax\ViesIdentifierFactory;
 use PHPUnit\Framework\TestCase;
 
@@ -14,6 +17,7 @@ final class ViesValueAddedTaxIdentifierFactoryTest extends TestCase
         $factory = new ViesIdentifierFactory(new Vies());
         $identifier = $factory->create('29480969591', 'FR');
 
+        self::assertTrue($identifier instanceof ValidatedIdentifier);
         self::assertEquals('FR29480969591', $identifier->toString());
     }
 
@@ -22,6 +26,15 @@ final class ViesValueAddedTaxIdentifierFactoryTest extends TestCase
         $factory = new ViesIdentifierFactory(new Vies());
         $identifier = $factory->create('6762461659', 'PL');
 
+        self::assertTrue($identifier instanceof SimpleIdentifier);
         self::assertEquals('6762461659', $identifier->toString());
+    }
+
+    public function testItIsInvalidIdentifier(): void
+    {
+        $factory = new ViesIdentifierFactory(new Vies());
+        $factory->create('333111222', 'DE');
+
+        self::expectException(Exception::class);
     }
 }

--- a/tests/Functional/Vies/ViesValueAddedTaxIdentifierFactoryTest.php
+++ b/tests/Functional/Vies/ViesValueAddedTaxIdentifierFactoryTest.php
@@ -17,22 +17,6 @@ final class ViesValueAddedTaxIdentifierFactoryTest extends TestCase
         self::assertEquals('FR29480969591', $identifier->toString());
     }
 
-    public function testItIsInvalidIdentifier(): void
-    {
-        $factory = new ViesIdentifierFactory(new Vies());
-        $identifier = $factory->create('333111222', 'DE');
-
-        self::assertEquals('333111222', $identifier->toString());
-    }
-
-    public function testItIsInvalidPolishIdentifier(): void
-    {
-        $factory = new ViesIdentifierFactory(new Vies());
-        $identifier = $factory->create('333111222', 'PL');
-
-        self::assertEquals('333111222', $identifier->toString());
-    }
-
     public function testItIsValidPolishIdentifier(): void
     {
         $factory = new ViesIdentifierFactory(new Vies());

--- a/tests/Functional/Vies/ViesValueAddedTaxIdentifierFactoryTest.php
+++ b/tests/Functional/Vies/ViesValueAddedTaxIdentifierFactoryTest.php
@@ -32,9 +32,9 @@ final class ViesValueAddedTaxIdentifierFactoryTest extends TestCase
 
     public function testItIsInvalidIdentifier(): void
     {
+        self::expectException(ViesException::class);
+
         $factory = new ViesIdentifierFactory(new Vies());
         $factory->create('333111222', 'DE');
-
-        self::expectException(ViesException::class);
     }
 }

--- a/tests/Functional/Wfirma/Invoice/CreateInvoiceTest.php
+++ b/tests/Functional/Wfirma/Invoice/CreateInvoiceTest.php
@@ -193,7 +193,7 @@ XML;
     {
         $contractor = $this->contractorBook->create(
             new Company(
-                new ContractorIdentifier('123'),
+                new ContractorIdentifier('222'),
                 new ContractorName('test foo'),
                 new ContractorEmail('test@landingi.com'),
                 new ContractorAddress(
@@ -203,7 +203,7 @@ XML;
                     new Country('FR')
                 ),
                 new Company\ValueAddedTax\ValidatedIdentifier(
-                    new Company\ValueAddedTax\SimpleIdentifier('53438681800015'),
+                    new Company\ValueAddedTax\SimpleIdentifier('47534386818'),
                     new Country('FR')
                 )
             )
@@ -221,7 +221,7 @@ XML;
             <country>FR</country>
             <email>test@landingi.com</email>
             <tax_id_type>vat</tax_id_type>
-            <nip>FR50844926014</nip>
+            <nip>FR53438681800015</nip>
         </contractor>
     </contractors>
 </api>

--- a/tests/Functional/Wfirma/Invoice/CreateInvoiceTest.php
+++ b/tests/Functional/Wfirma/Invoice/CreateInvoiceTest.php
@@ -221,7 +221,7 @@ XML;
             <country>FR</country>
             <email>test@landingi.com</email>
             <tax_id_type>vat</tax_id_type>
-            <nip>FR53438681800015</nip>
+            <nip>FR47534386818</nip>
         </contractor>
     </contractors>
 </api>

--- a/tests/Functional/Wfirma/Invoice/CreateInvoiceTest.php
+++ b/tests/Functional/Wfirma/Invoice/CreateInvoiceTest.php
@@ -242,6 +242,7 @@ XML;
                         new WfirmaValueAddedTax(WfirmaValueAddedTax::NO_TAX, new ValueAddedTax(0)),
                         new NumberOfUnits(2)
                     ),
+
                 ]),
                 $contractor,
                 new Currency('EUR'),

--- a/tests/Functional/Wfirma/Invoice/CreateInvoiceTest.php
+++ b/tests/Functional/Wfirma/Invoice/CreateInvoiceTest.php
@@ -202,7 +202,7 @@ XML;
                     new City('Paris'),
                     new Country('FR')
                 ),
-                new Company\ValueAddedTax\SimpleIdentifier('50844926014')
+                new Company\ValueAddedTax\SimpleIdentifier('99999999999')
             )
         );
         $contractorRequest = <<<XML

--- a/tests/Functional/Wfirma/Invoice/CreateInvoiceTest.php
+++ b/tests/Functional/Wfirma/Invoice/CreateInvoiceTest.php
@@ -312,7 +312,7 @@ XML;
                     new City('London'),
                     new Country('GB')
                 ),
-                new Company\ValueAddedTax\SimpleIdentifier('50844926014')
+                new Company\ValueAddedTax\SimpleIdentifier('550844926014')
             )
         );
         $contractorRequest = <<<XML

--- a/tests/Functional/Wfirma/Invoice/CreateInvoiceTest.php
+++ b/tests/Functional/Wfirma/Invoice/CreateInvoiceTest.php
@@ -202,7 +202,10 @@ XML;
                     new City('Paris'),
                     new Country('FR')
                 ),
-                new Company\ValueAddedTax\SimpleIdentifier('53438681800015')
+                new Company\ValueAddedTax\ValidatedIdentifier(
+                    new Company\ValueAddedTax\SimpleIdentifier('53438681800015'),
+                    new Country('FR')
+                )
             )
         );
         $contractorRequest = <<<XML

--- a/tests/Functional/Wfirma/Invoice/CreateInvoiceTest.php
+++ b/tests/Functional/Wfirma/Invoice/CreateInvoiceTest.php
@@ -328,7 +328,7 @@ XML;
             <country>GB</country>
             <email>test@landingi.com</email>
             <tax_id_type>custom</tax_id_type>
-            <nip>GB50844926014</nip>
+            <nip>GB550844926014</nip>
         </contractor>
     </contractors>
 </api>

--- a/tests/Functional/Wfirma/Invoice/CreateInvoiceTest.php
+++ b/tests/Functional/Wfirma/Invoice/CreateInvoiceTest.php
@@ -202,7 +202,7 @@ XML;
                     new City('Paris'),
                     new Country('FR')
                 ),
-                new Company\ValueAddedTax\SimpleIdentifier('99999999999')
+                new Company\ValueAddedTax\SimpleIdentifier('53438681800015')
             )
         );
         $contractorRequest = <<<XML

--- a/tests/Functional/Wfirma/Invoice/CreateInvoiceTest.php
+++ b/tests/Functional/Wfirma/Invoice/CreateInvoiceTest.php
@@ -224,7 +224,6 @@ XML;
             <nip>FR47534386818</nip>
         </contractor>
     </contractors>
-    
 </api>
 XML;
         self::assertXmlStringEqualsXmlString($contractorRequest, $contractor->print(WfirmaMedia::api())->toString());

--- a/tests/Functional/Wfirma/Invoice/CreateInvoiceTest.php
+++ b/tests/Functional/Wfirma/Invoice/CreateInvoiceTest.php
@@ -242,7 +242,6 @@ XML;
                         new WfirmaValueAddedTax(WfirmaValueAddedTax::NO_TAX, new ValueAddedTax(0)),
                         new NumberOfUnits(2)
                     ),
-
                 ]),
                 $contractor,
                 new Currency('EUR'),

--- a/tests/Functional/Wfirma/Invoice/CreateInvoiceTest.php
+++ b/tests/Functional/Wfirma/Invoice/CreateInvoiceTest.php
@@ -224,6 +224,7 @@ XML;
             <nip>FR47534386818</nip>
         </contractor>
     </contractors>
+    
 </api>
 XML;
         self::assertXmlStringEqualsXmlString($contractorRequest, $contractor->print(WfirmaMedia::api())->toString());

--- a/tests/Functional/Wfirma/Invoice/CreateInvoiceTest.php
+++ b/tests/Functional/Wfirma/Invoice/CreateInvoiceTest.php
@@ -193,7 +193,7 @@ XML;
     {
         $contractor = $this->contractorBook->create(
             new Company(
-                new ContractorIdentifier('222'),
+                new ContractorIdentifier('123'),
                 new ContractorName('test foo'),
                 new ContractorEmail('test@landingi.com'),
                 new ContractorAddress(

--- a/tests/Functional/Wfirma/Invoice/DownloadInvoiceTest.php
+++ b/tests/Functional/Wfirma/Invoice/DownloadInvoiceTest.php
@@ -44,7 +44,6 @@ use PHPUnit\Framework\TestCase;
 
 class DownloadInvoiceTest extends TestCase
 {
-
     private ContractorBook $contractorBook;
     private InvoiceBook $invoiceBook;
     private DateTime $today;

--- a/tests/Functional/Wfirma/Invoice/DownloadInvoiceTest.php
+++ b/tests/Functional/Wfirma/Invoice/DownloadInvoiceTest.php
@@ -44,6 +44,7 @@ use PHPUnit\Framework\TestCase;
 
 class DownloadInvoiceTest extends TestCase
 {
+
     private ContractorBook $contractorBook;
     private InvoiceBook $invoiceBook;
     private DateTime $today;

--- a/tests/Functional/Wfirma/Invoice/DownloadInvoiceTest.php
+++ b/tests/Functional/Wfirma/Invoice/DownloadInvoiceTest.php
@@ -79,7 +79,7 @@ class DownloadInvoiceTest extends TestCase
                     new City('test'),
                     new Country('PL')
                 ),
-                new Company\ValueAddedTax\SimpleIdentifier('6762461659')
+                new Company\ValueAddedTax\SimpleIdentifier('1579406095')
             )
         );
         $invoice = $this->invoiceBook->create(

--- a/tests/Functional/Wfirma/Invoice/DownloadInvoiceTest.php
+++ b/tests/Functional/Wfirma/Invoice/DownloadInvoiceTest.php
@@ -79,7 +79,7 @@ class DownloadInvoiceTest extends TestCase
                     new City('test'),
                     new Country('PL')
                 ),
-                new Company\ValueAddedTax\SimpleIdentifier('1579406095')
+                new Company\ValueAddedTax\SimpleIdentifier('6762461659')
             )
         );
         $invoice = $this->invoiceBook->create(


### PR DESCRIPTION
This PR will add throwing exception if indicating the VAT number is invalid. Return instance of SimpleIdentifier with non-valid vat number will make a bug like https://landingi.sentry.io/issues/3042134860/?project=5395591.