### PR TITLE
Allow invoice item unit count to be zero 

### DIFF
--- a/src/Bookkeeping/Invoice/InvoiceItem/NumberOfUnits.php
+++ b/src/Bookkeeping/Invoice/InvoiceItem/NumberOfUnits.php
@@ -10,12 +10,14 @@ final class NumberOfUnits
     private int $number;
 
     /**
+     * Note: If the invoice is a correction, the number of units of an invoice item can be zero.
+     *
      * @throws InvoiceItemException
      */
     public function __construct(int $number)
     {
-        if ($number < 1) {
-            throw new InvoiceItemException('The number of units must not be less than 1');
+        if ($number < 0) {
+            throw new InvoiceItemException('The number of units must not be less than 0');
         }
 
         $this->number = $number;

--- a/tests/Unit/Bookkeeping/Invoice/InvoiceItem/NumberOfUnitsTest.php
+++ b/tests/Unit/Bookkeeping/Invoice/InvoiceItem/NumberOfUnitsTest.php
@@ -15,13 +15,15 @@ final class NumberOfUnitsTest extends TestCase
         self::assertEquals('1', $units->toString());
         self::assertEquals('1', (string) $units);
         self::assertEquals(1, $units->toInteger());
+
+        $units = new NumberOfUnits(0);
+        self::assertEquals('0', $units->toString());
+        self::assertEquals('0', (string) $units);
+        self::assertEquals(0, $units->toInteger());
     }
 
-    public function testItIsNotEmptyString(): void
+    public function testItIsNotNegative(): void
     {
-        $this->expectException(InvoiceItemException::class);
-        new NumberOfUnits(0);
-
         $this->expectException(InvoiceItemException::class);
         new NumberOfUnits(-1);
     }


### PR DESCRIPTION
This happens when an invoice is a correction.