### PR TITLE
Add ExpenseBook capable of listing expenses

### DIFF
--- a/src/Bookkeeping/Collection/CollectionCondition.php
+++ b/src/Bookkeeping/Collection/CollectionCondition.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Landingi\BookkeepingBundle\Bookkeeping\Collection;
+
+interface CollectionCondition
+{
+    public function __toString(): string;
+}

--- a/src/Bookkeeping/Expense/Collection/Condition/ExactExpenseDate.php
+++ b/src/Bookkeeping/Expense/Collection/Condition/ExactExpenseDate.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace Landingi\BookkeepingBundle\Bookkeeping\Invoice\Collection\Condition;
+namespace Landingi\BookkeepingBundle\Bookkeeping\Expense\Collection\Condition;
 
 use DateTimeImmutable;
-use Landingi\BookkeepingBundle\Bookkeeping\Invoice\Collection\InvoiceCondition;
+use Landingi\BookkeepingBundle\Bookkeeping\Expense\Collection\ExpenseCondition;
 
-final class ExactDate implements InvoiceCondition
+final class ExactExpenseDate implements ExpenseCondition
 {
     private DateTimeImmutable $date;
 

--- a/src/Bookkeeping/Expense/Collection/Condition/ExcludeExpenseSeries.php
+++ b/src/Bookkeeping/Expense/Collection/Condition/ExcludeExpenseSeries.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Landingi\BookkeepingBundle\Bookkeeping\Expense\Collection\Condition;
+
+use Landingi\BookkeepingBundle\Bookkeeping\Expense\Collection\ExpenseCondition;
+
+final class ExcludeExpenseSeries implements ExpenseCondition
+{
+    private string $expenseSeries;
+
+    public function __construct(string $expenseSeries)
+    {
+        $this->expenseSeries = $expenseSeries;
+    }
+
+    public function __toString(): string
+    {
+        return $this->expenseSeries;
+    }
+}

--- a/src/Bookkeeping/Expense/Collection/Condition/ExcludeExpenseSeries.php
+++ b/src/Bookkeeping/Expense/Collection/Condition/ExcludeExpenseSeries.php
@@ -11,7 +11,7 @@ final class ExcludeExpenseSeries implements ExpenseCondition
     private string $expenseNumberFragment;
 
     /**
-     * This accepts a fragment of the expense's full number, to compare against
+     * This accepts a fragment of the expense's full number, to compare against.
      */
     public function __construct(string $expenseNumberFragment)
     {

--- a/src/Bookkeeping/Expense/Collection/Condition/ExcludeExpenseSeries.php
+++ b/src/Bookkeeping/Expense/Collection/Condition/ExcludeExpenseSeries.php
@@ -8,15 +8,18 @@ use Landingi\BookkeepingBundle\Bookkeeping\Expense\Collection\ExpenseCondition;
 
 final class ExcludeExpenseSeries implements ExpenseCondition
 {
-    private string $expenseSeries;
+    private string $expenseNumberFragment;
 
-    public function __construct(string $expenseSeries)
+    /**
+     * This accepts a fragment of the expense's full number, to compare against
+     */
+    public function __construct(string $expenseNumberFragment)
     {
-        $this->expenseSeries = $expenseSeries;
+        $this->expenseNumberFragment = $expenseNumberFragment;
     }
 
     public function __toString(): string
     {
-        return $this->expenseSeries;
+        return $this->expenseNumberFragment;
     }
 }

--- a/src/Bookkeeping/Expense/Collection/ExpenseCondition.php
+++ b/src/Bookkeeping/Expense/Collection/ExpenseCondition.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Landingi\BookkeepingBundle\Bookkeeping\Expense\Collection;
+
+use Landingi\BookkeepingBundle\Bookkeeping\Collection\CollectionCondition;
+
+interface ExpenseCondition extends CollectionCondition
+{
+    public function __toString(): string;
+}

--- a/src/Bookkeeping/Expense/Exception/ExpenseException.php
+++ b/src/Bookkeeping/Expense/Exception/ExpenseException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Landingi\BookkeepingBundle\Bookkeeping\Expense\Exception;
+
+use Landingi\BookkeepingBundle\Bookkeeping\BookkeepingException;
+
+final class ExpenseException extends BookkeepingException
+{
+}

--- a/src/Bookkeeping/Expense/ExpenseBook.php
+++ b/src/Bookkeeping/Expense/ExpenseBook.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Landingi\BookkeepingBundle\Bookkeeping\Expense;
+
+use Landingi\BookkeepingBundle\Bookkeeping\Collection;
+use Landingi\BookkeepingBundle\Bookkeeping\Expense\Collection\ExpenseCondition;
+
+interface ExpenseBook
+{
+    public function listSummaries(int $page, ExpenseCondition ...$conditions): Collection;
+}

--- a/src/Bookkeeping/Expense/ExpenseIdentifier.php
+++ b/src/Bookkeeping/Expense/ExpenseIdentifier.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Landingi\BookkeepingBundle\Bookkeeping\Expense;
+
+final class ExpenseIdentifier
+{
+    private string $identifier;
+
+    public function __construct(string $identifier)
+    {
+        $this->identifier = $identifier;
+    }
+
+    public function toString(): string
+    {
+        return $this->identifier;
+    }
+
+    public function __toString(): string
+    {
+        return $this->toString();
+    }
+}

--- a/src/Bookkeeping/Expense/ExpenseNetPlnValue.php
+++ b/src/Bookkeeping/Expense/ExpenseNetPlnValue.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Landingi\BookkeepingBundle\Bookkeeping\Expense;
+
+use Landingi\BookkeepingBundle\Bookkeeping\Expense\Exception\ExpenseException;
+
+final class ExpenseNetPlnValue
+{
+    private int $netPlnValue;
+
+    /**
+     * Provide $netPlnValue in "cents". This is returned in PLN.
+     * This can be negative if the expense is a correction.
+     *
+     * @throws ExpenseException
+     */
+    public function __construct(int $netPlnValue)
+    {
+        if (0 === $netPlnValue) {
+            throw new ExpenseException('Netto PLN Value cannot be zero');
+        }
+
+        $this->netPlnValue = $netPlnValue;
+    }
+
+    public function toString(): string
+    {
+        return (string) $this->toFloat();
+    }
+
+    public function __toString(): string
+    {
+        return $this->toString();
+    }
+
+    public function toFloat(): float
+    {
+        return $this->netPlnValue / 100;
+    }
+}

--- a/src/Bookkeeping/ExpenseSummary.php
+++ b/src/Bookkeeping/ExpenseSummary.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Landingi\BookkeepingBundle\Bookkeeping;
+
+use Landingi\BookkeepingBundle\Bookkeeping\Expense\ExpenseIdentifier;
+use Landingi\BookkeepingBundle\Bookkeeping\Expense\ExpenseNetPlnValue;
+
+final class ExpenseSummary
+{
+    private ExpenseIdentifier $identifier;
+    private ExpenseNetPlnValue $netPlnValue;
+
+    public function __construct(
+        ExpenseIdentifier $identifier,
+        ExpenseNetPlnValue $netPlnValue
+    ) {
+        $this->identifier = $identifier;
+        $this->netPlnValue = $netPlnValue;
+    }
+
+    public function getIdentifier(): ExpenseIdentifier
+    {
+        return $this->identifier;
+    }
+
+    public function getNetPlnValue(): ExpenseNetPlnValue
+    {
+        return $this->netPlnValue;
+    }
+}

--- a/src/Bookkeeping/Invoice.php
+++ b/src/Bookkeeping/Invoice.php
@@ -79,11 +79,6 @@ abstract class Invoice
         return $this->identifier;
     }
 
-    public function getInvoiceSeries(): InvoiceSeries
-    {
-        return $this->invoiceSeries;
-    }
-
     public function getFullNumber(): InvoiceFullNumber
     {
         return $this->fullNumber;

--- a/src/Bookkeeping/Invoice.php
+++ b/src/Bookkeeping/Invoice.php
@@ -79,6 +79,11 @@ abstract class Invoice
         return $this->identifier;
     }
 
+    public function getInvoiceSeries(): InvoiceSeries
+    {
+        return $this->invoiceSeries;
+    }
+
     public function getFullNumber(): InvoiceFullNumber
     {
         return $this->fullNumber;

--- a/src/Bookkeeping/Invoice/Collection/Condition/ExcludeSeries.php
+++ b/src/Bookkeeping/Invoice/Collection/Condition/ExcludeSeries.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Landingi\BookkeepingBundle\Bookkeeping\Invoice\Collection\Condition;
 
-use Landingi\BookkeepingBundle\Bookkeeping\Invoice\Collection\Condition;
+use Landingi\BookkeepingBundle\Bookkeeping\Invoice\Collection\InvoiceCondition;
 
-final class ExcludeSeries implements Condition
+final class ExcludeSeries implements InvoiceCondition
 {
     private string $invoiceSeries;
 

--- a/src/Bookkeeping/Invoice/Collection/Condition/ExcludeSeries.php
+++ b/src/Bookkeeping/Invoice/Collection/Condition/ExcludeSeries.php
@@ -8,15 +8,18 @@ use Landingi\BookkeepingBundle\Bookkeeping\Invoice\Collection\InvoiceCondition;
 
 final class ExcludeSeries implements InvoiceCondition
 {
-    private string $invoiceSeries;
+    private string $invoiceNumberFragment;
 
-    public function __construct(string $invoiceSeries)
+    /**
+     * This accepts a fragment of the invoice's full number, to compare against
+     */
+    public function __construct(string $invoiceNumberFragment)
     {
-        $this->invoiceSeries = $invoiceSeries;
+        $this->invoiceNumberFragment = $invoiceNumberFragment;
     }
 
     public function __toString(): string
     {
-        return $this->invoiceSeries;
+        return $this->invoiceNumberFragment;
     }
 }

--- a/src/Bookkeeping/Invoice/Collection/Condition/ExcludeSeries.php
+++ b/src/Bookkeeping/Invoice/Collection/Condition/ExcludeSeries.php
@@ -11,7 +11,7 @@ final class ExcludeSeries implements InvoiceCondition
     private string $invoiceNumberFragment;
 
     /**
-     * This accepts a fragment of the invoice's full number, to compare against
+     * This accepts a fragment of the invoice's full number, to compare against.
      */
     public function __construct(string $invoiceNumberFragment)
     {

--- a/src/Bookkeeping/Invoice/Collection/Condition/IncludeSeries.php
+++ b/src/Bookkeeping/Invoice/Collection/Condition/IncludeSeries.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Landingi\BookkeepingBundle\Bookkeeping\Invoice\Collection\Condition;
 
-use Landingi\BookkeepingBundle\Bookkeeping\Invoice\Collection\Condition;
+use Landingi\BookkeepingBundle\Bookkeeping\Invoice\Collection\InvoiceCondition;
 
-final class IncludeSeries implements Condition
+final class IncludeSeries implements InvoiceCondition
 {
     private string $invoiceSeries;
 

--- a/src/Bookkeeping/Invoice/Collection/Condition/IncludeSeries.php
+++ b/src/Bookkeeping/Invoice/Collection/Condition/IncludeSeries.php
@@ -8,15 +8,18 @@ use Landingi\BookkeepingBundle\Bookkeeping\Invoice\Collection\InvoiceCondition;
 
 final class IncludeSeries implements InvoiceCondition
 {
-    private string $invoiceSeries;
+    private string $invoiceNumberFragment;
 
-    public function __construct(string $invoiceSeries)
+    /**
+     * This accepts a fragment of the invoice's full number, to compare against
+     */
+    public function __construct(string $invoiceNumberFragment)
     {
-        $this->invoiceSeries = $invoiceSeries;
+        $this->invoiceNumberFragment = $invoiceNumberFragment;
     }
 
     public function __toString(): string
     {
-        return $this->invoiceSeries;
+        return $this->invoiceNumberFragment;
     }
 }

--- a/src/Bookkeeping/Invoice/Collection/Condition/IncludeSeries.php
+++ b/src/Bookkeeping/Invoice/Collection/Condition/IncludeSeries.php
@@ -11,7 +11,7 @@ final class IncludeSeries implements InvoiceCondition
     private string $invoiceNumberFragment;
 
     /**
-     * This accepts a fragment of the invoice's full number, to compare against
+     * This accepts a fragment of the invoice's full number, to compare against.
      */
     public function __construct(string $invoiceNumberFragment)
     {

--- a/src/Bookkeeping/Invoice/Collection/InvoiceCondition.php
+++ b/src/Bookkeeping/Invoice/Collection/InvoiceCondition.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Landingi\BookkeepingBundle\Bookkeeping\Invoice\Collection;
 
-interface Condition
+use Landingi\BookkeepingBundle\Bookkeeping\Collection\CollectionCondition;
+
+interface InvoiceCondition extends CollectionCondition
 {
     public function __toString(): string;
 }

--- a/src/Bookkeeping/Invoice/InvoiceBook.php
+++ b/src/Bookkeeping/Invoice/InvoiceBook.php
@@ -5,13 +5,13 @@ namespace Landingi\BookkeepingBundle\Bookkeeping\Invoice;
 
 use Landingi\BookkeepingBundle\Bookkeeping\Collection;
 use Landingi\BookkeepingBundle\Bookkeeping\Invoice;
-use Landingi\BookkeepingBundle\Bookkeeping\Invoice\Collection\Condition;
+use Landingi\BookkeepingBundle\Bookkeeping\Invoice\Collection\InvoiceCondition;
 
 interface InvoiceBook
 {
     public function find(InvoiceIdentifier $identifier): Invoice;
-    public function list(int $page, Condition ...$conditions): Collection;
-    public function listSummaries(int $page, Condition ...$conditions): Collection;
+    public function list(int $page, InvoiceCondition ...$conditions): Collection;
+    public function listSummaries(int $page, InvoiceCondition ...$conditions): Collection;
     public function create(Invoice $invoice): Invoice;
     public function delete(InvoiceIdentifier $identifier): void;
     public function download(InvoiceIdentifier $identifier): string;

--- a/src/Wfirma/Client/Request/Expenses/FindExpenses.php
+++ b/src/Wfirma/Client/Request/Expenses/FindExpenses.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Landingi\BookkeepingBundle\Wfirma\Client\Request\Expenses;
+
+use Landingi\BookkeepingBundle\Wfirma\Client\Request;
+
+final class FindExpenses implements Request
+{
+    private int $page;
+    private string $conditionXml;
+
+    public function __construct(string $conditionXml, int $page = 1)
+    {
+        $this->conditionXml = $conditionXml;
+        $this->page = $page;
+    }
+
+    public function getContent(): string
+    {
+        return <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<api>
+    <expenses>
+        <parameters>
+            <conditions>
+                <and>
+                    $this->conditionXml   
+                </and>
+            </conditions>
+            <page>$this->page</page>
+        </parameters>
+    </expenses>
+</api>
+XML;
+    }
+
+    public function __toString(): string
+    {
+        return $this->getContent();
+    }
+}

--- a/src/Wfirma/Client/WfirmaConditionTransformer.php
+++ b/src/Wfirma/Client/WfirmaConditionTransformer.php
@@ -9,10 +9,10 @@ use Landingi\BookkeepingBundle\Bookkeeping\Collection\CollectionCondition;
 use Landingi\BookkeepingBundle\Bookkeeping\Expense\Collection\Condition\ExactExpenseDate;
 use Landingi\BookkeepingBundle\Bookkeeping\Expense\Collection\Condition\ExcludeExpenseSeries;
 use Landingi\BookkeepingBundle\Bookkeeping\Expense\Collection\ExpenseCondition;
-use Landingi\BookkeepingBundle\Bookkeeping\Invoice\Collection\InvoiceCondition;
 use Landingi\BookkeepingBundle\Bookkeeping\Invoice\Collection\Condition\ExactDate;
 use Landingi\BookkeepingBundle\Bookkeeping\Invoice\Collection\Condition\ExcludeSeries;
 use Landingi\BookkeepingBundle\Bookkeeping\Invoice\Collection\Condition\IncludeSeries;
+use Landingi\BookkeepingBundle\Bookkeeping\Invoice\Collection\InvoiceCondition;
 
 final class WfirmaConditionTransformer
 {

--- a/src/Wfirma/Client/WfirmaConditionTransformer.php
+++ b/src/Wfirma/Client/WfirmaConditionTransformer.php
@@ -5,14 +5,31 @@ declare(strict_types=1);
 namespace Landingi\BookkeepingBundle\Wfirma\Client;
 
 use InvalidArgumentException;
-use Landingi\BookkeepingBundle\Bookkeeping\Invoice\Collection\Condition;
+use Landingi\BookkeepingBundle\Bookkeeping\Collection\CollectionCondition;
+use Landingi\BookkeepingBundle\Bookkeeping\Expense\Collection\Condition\ExactExpenseDate;
+use Landingi\BookkeepingBundle\Bookkeeping\Expense\Collection\Condition\ExcludeExpenseSeries;
+use Landingi\BookkeepingBundle\Bookkeeping\Expense\Collection\ExpenseCondition;
+use Landingi\BookkeepingBundle\Bookkeeping\Invoice\Collection\InvoiceCondition;
 use Landingi\BookkeepingBundle\Bookkeeping\Invoice\Collection\Condition\ExactDate;
 use Landingi\BookkeepingBundle\Bookkeeping\Invoice\Collection\Condition\ExcludeSeries;
 use Landingi\BookkeepingBundle\Bookkeeping\Invoice\Collection\Condition\IncludeSeries;
 
 final class WfirmaConditionTransformer
 {
-    public function toXml(Condition $condition): string
+    public function toXml(CollectionCondition $condition): string
+    {
+        if ($condition instanceof InvoiceCondition) {
+            return $this->buildInvoiceCondition($condition);
+        }
+
+        if ($condition instanceof ExpenseCondition) {
+            return $this->buildExpenseCondition($condition);
+        }
+
+        throw new InvalidArgumentException('Provided collection condition is not supported');
+    }
+
+    private function buildInvoiceCondition(InvoiceCondition $condition): string
     {
         if ($condition instanceof ExactDate) {
             return $this->buildExactDateXml($condition);
@@ -26,10 +43,23 @@ final class WfirmaConditionTransformer
             return $this->buildExcludeSeriesXml($condition);
         }
 
-        throw new InvalidArgumentException('Provided condition is not supported');
+        throw new InvalidArgumentException('Provided invoice condition is not supported');
     }
 
-    private function buildExactDateXml(ExactDate $condition): string
+    private function buildExpenseCondition(ExpenseCondition $condition): string
+    {
+        if ($condition instanceof ExactExpenseDate) {
+            return $this->buildExactDateXml($condition);
+        }
+
+        if ($condition instanceof ExcludeExpenseSeries) {
+            return $this->buildExcludeSeriesXml($condition);
+        }
+
+        throw new InvalidArgumentException('Provided expense condition is not supported');
+    }
+
+    private function buildExactDateXml(CollectionCondition $condition): string
     {
         return <<<XML
 <condition>
@@ -40,7 +70,7 @@ final class WfirmaConditionTransformer
 XML;
     }
 
-    private function buildIncludeSeriesXml(IncludeSeries $condition): string
+    private function buildIncludeSeriesXml(CollectionCondition $condition): string
     {
         return <<<XML
 <condition>
@@ -51,7 +81,7 @@ XML;
 XML;
     }
 
-    private function buildExcludeSeriesXml(ExcludeSeries $condition): string
+    private function buildExcludeSeriesXml(CollectionCondition $condition): string
     {
         return <<<XML
 <condition>

--- a/src/Wfirma/Expense/Factory/ExpenseSummaryFactory.php
+++ b/src/Wfirma/Expense/Factory/ExpenseSummaryFactory.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Landingi\BookkeepingBundle\Wfirma\Expense\Factory;
+
+use Landingi\BookkeepingBundle\Bookkeeping\Expense\ExpenseIdentifier;
+use Landingi\BookkeepingBundle\Bookkeeping\Expense\ExpenseNetPlnValue;
+use Landingi\BookkeepingBundle\Bookkeeping\ExpenseSummary;
+
+final class ExpenseSummaryFactory
+{
+    public function getSummaryFromApiData(array $data): ExpenseSummary
+    {
+        return new ExpenseSummary(
+            new ExpenseIdentifier((string) $data['id']),
+            new ExpenseNetPlnValue((int) ($data['netto'] * 100))
+        );
+    }
+}

--- a/src/Wfirma/Expense/WfirmaExpenseBook.php
+++ b/src/Wfirma/Expense/WfirmaExpenseBook.php
@@ -7,7 +7,6 @@ namespace Landingi\BookkeepingBundle\Wfirma\Expense;
 use Landingi\BookkeepingBundle\Bookkeeping\Collection;
 use Landingi\BookkeepingBundle\Bookkeeping\Expense\Collection\ExpenseCondition;
 use Landingi\BookkeepingBundle\Bookkeeping\Expense\ExpenseBook;
-use Landingi\BookkeepingBundle\Bookkeeping\Invoice\Collection\InvoiceCondition;
 use Landingi\BookkeepingBundle\Wfirma\Client\WfirmaClient;
 use Landingi\BookkeepingBundle\Wfirma\Expense\Factory\ExpenseSummaryFactory;
 

--- a/src/Wfirma/Expense/WfirmaExpenseBook.php
+++ b/src/Wfirma/Expense/WfirmaExpenseBook.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Landingi\BookkeepingBundle\Wfirma\Expense;
+
+use Landingi\BookkeepingBundle\Bookkeeping\Collection;
+use Landingi\BookkeepingBundle\Bookkeeping\Expense\Collection\ExpenseCondition;
+use Landingi\BookkeepingBundle\Bookkeeping\Expense\ExpenseBook;
+use Landingi\BookkeepingBundle\Bookkeeping\Invoice\Collection\InvoiceCondition;
+use Landingi\BookkeepingBundle\Wfirma\Client\WfirmaClient;
+use Landingi\BookkeepingBundle\Wfirma\Expense\Factory\ExpenseSummaryFactory;
+
+final class WfirmaExpenseBook implements ExpenseBook
+{
+    private const EXPENSES_FIND_URL = '/expenses/find';
+
+    private WfirmaClient $client;
+    private ExpenseSummaryFactory $summaryFactory;
+
+    public function __construct(WfirmaClient $client, ExpenseSummaryFactory $summaryFactory)
+    {
+        $this->client = $client;
+        $this->summaryFactory = $summaryFactory;
+    }
+
+    public function listSummaries(int $page, ExpenseCondition ...$conditions): Collection
+    {
+        $result = $this->client->findExpenses(self::EXPENSES_FIND_URL, $page, ...$conditions);
+        $summaryCollection = new Collection(
+            array_map(
+                function (array $expenseResult) {
+                    return $this->summaryFactory->getSummaryFromApiData($expenseResult['expense']);
+                },
+                array_filter($result['expenses'], static function (array $expenseResult) {
+                    return false === empty($expenseResult['expense']);
+                })
+            )
+        );
+
+        if ($result['expenses']['parameters']['total'] > $page * (int) $result['expenses']['parameters']['limit']) {
+            $summaryCollection->merge($this->listSummaries($page + 1, ...$conditions));
+        }
+
+        return $summaryCollection;
+    }
+}

--- a/src/Wfirma/Invoice/WfirmaInvoiceBook.php
+++ b/src/Wfirma/Invoice/WfirmaInvoiceBook.php
@@ -7,7 +7,7 @@ use JsonException;
 use Landingi\BookkeepingBundle\Bookkeeping\Collection;
 use Landingi\BookkeepingBundle\Bookkeeping\Contractor;
 use Landingi\BookkeepingBundle\Bookkeeping\Invoice;
-use Landingi\BookkeepingBundle\Bookkeeping\Invoice\Collection\Condition;
+use Landingi\BookkeepingBundle\Bookkeeping\Invoice\Collection\InvoiceCondition;
 use Landingi\BookkeepingBundle\Bookkeeping\Invoice\InvoiceBook;
 use Landingi\BookkeepingBundle\Bookkeeping\Invoice\InvoiceIdentifier;
 use Landingi\BookkeepingBundle\Wfirma\Client\WfirmaClient;
@@ -65,7 +65,7 @@ final class WfirmaInvoiceBook implements InvoiceBook
         );
     }
 
-    public function list(int $page, Condition ...$conditions): Collection
+    public function list(int $page, InvoiceCondition ...$conditions): Collection
     {
         $result = $this->client->findInvoices(self::INVOICES_FIND_URL, $page, ...$conditions);
         $invoiceCollection = new WfirmaInvoiceCollection(
@@ -91,7 +91,7 @@ final class WfirmaInvoiceBook implements InvoiceBook
         return $invoiceCollection;
     }
 
-    public function listSummaries(int $page, Condition ...$conditions): Collection
+    public function listSummaries(int $page, InvoiceCondition ...$conditions): Collection
     {
         $result = $this->client->findInvoices(self::INVOICES_FIND_URL, $page, ...$conditions);
         $summaryCollection = new Collection(

--- a/tests/Integration/Wfirma/Invoice/WfirmaExpenseBookTest.php
+++ b/tests/Integration/Wfirma/Invoice/WfirmaExpenseBookTest.php
@@ -34,6 +34,10 @@ final class WfirmaExpenseBookTest extends IntegrationTestCase
         );
     }
 
+    /**
+     * The predefined expense in this test should be replaced with a created one, whenever
+     * the option to add an expense is added to the bundle
+     */
     public function testItListsExpenseSummaries(): void
     {
         $conditions = [
@@ -44,7 +48,7 @@ final class WfirmaExpenseBookTest extends IntegrationTestCase
         $this->assertCount(1, $summaryArray = $summaries->getAll());
         /** @var ExpenseSummary $summary */
         $summary = $summaryArray[0];
-        $this->assertEquals('EXP 1', $summary->getIdentifier());
+        $this->assertEquals('82866659', $summary->getIdentifier());
         $this->assertEquals(2137.00, $summary->getNetPlnValue()->toFloat());
     }
 }

--- a/tests/Integration/Wfirma/Invoice/WfirmaExpenseBookTest.php
+++ b/tests/Integration/Wfirma/Invoice/WfirmaExpenseBookTest.php
@@ -42,7 +42,7 @@ final class WfirmaExpenseBookTest extends IntegrationTestCase
     {
         $conditions = [
             new ExactExpenseDate(new \DateTimeImmutable('2023-05-15')),
-            new ExcludeExpenseSeries((string) 'foo'),
+            new ExcludeExpenseSeries((string) 'some-nonexistent-fullnumber-fragment'),
         ];
         $summaries = $this->expenseBook->listSummaries(1, ...$conditions);
         $this->assertCount(1, $summaryArray = $summaries->getAll());

--- a/tests/Integration/Wfirma/Invoice/WfirmaExpenseBookTest.php
+++ b/tests/Integration/Wfirma/Invoice/WfirmaExpenseBookTest.php
@@ -1,0 +1,88 @@
+<?php
+declare(strict_types=1);
+
+namespace Landingi\BookkeepingBundle\Integration\Wfirma\Invoice;
+
+use DateTime;
+use Landingi\BookkeepingBundle\Bookkeeping\Contractor;
+use Landingi\BookkeepingBundle\Bookkeeping\Contractor\Address\City;
+use Landingi\BookkeepingBundle\Bookkeeping\Contractor\Address\Country;
+use Landingi\BookkeepingBundle\Bookkeeping\Contractor\Address\PostalCode;
+use Landingi\BookkeepingBundle\Bookkeeping\Contractor\Address\Street;
+use Landingi\BookkeepingBundle\Bookkeeping\Contractor\ContractorAddress;
+use Landingi\BookkeepingBundle\Bookkeeping\Contractor\ContractorEmail;
+use Landingi\BookkeepingBundle\Bookkeeping\Contractor\ContractorIdentifier;
+use Landingi\BookkeepingBundle\Bookkeeping\Contractor\ContractorName;
+use Landingi\BookkeepingBundle\Bookkeeping\Contractor\Person;
+use Landingi\BookkeepingBundle\Bookkeeping\Currency;
+use Landingi\BookkeepingBundle\Bookkeeping\Expense\Collection\Condition\ExactExpenseDate;
+use Landingi\BookkeepingBundle\Bookkeeping\Expense\Collection\Condition\ExcludeExpenseSeries;
+use Landingi\BookkeepingBundle\Bookkeeping\Expense\ExpenseBook;
+use Landingi\BookkeepingBundle\Bookkeeping\ExpenseSummary;
+use Landingi\BookkeepingBundle\Bookkeeping\Invoice\Collection\Condition\ExactDate;
+use Landingi\BookkeepingBundle\Bookkeeping\Invoice\Collection\Condition\ExcludeSeries;
+use Landingi\BookkeepingBundle\Bookkeeping\Invoice\Collection\Condition\IncludeSeries;
+use Landingi\BookkeepingBundle\Bookkeeping\Invoice\InvoiceBook;
+use Landingi\BookkeepingBundle\Bookkeeping\Invoice\InvoiceDescription;
+use Landingi\BookkeepingBundle\Bookkeeping\Invoice\InvoiceFullNumber;
+use Landingi\BookkeepingBundle\Bookkeeping\Invoice\InvoiceIdentifier;
+use Landingi\BookkeepingBundle\Bookkeeping\Invoice\InvoiceItem\Name;
+use Landingi\BookkeepingBundle\Bookkeeping\Invoice\InvoiceItem\NumberOfUnits;
+use Landingi\BookkeepingBundle\Bookkeeping\Invoice\InvoiceItem\Price;
+use Landingi\BookkeepingBundle\Bookkeeping\Invoice\InvoiceItem\ValueAddedTax;
+use Landingi\BookkeepingBundle\Bookkeeping\Invoice\InvoiceNetPlnValue;
+use Landingi\BookkeepingBundle\Bookkeeping\Invoice\InvoiceSeries;
+use Landingi\BookkeepingBundle\Bookkeeping\Invoice\InvoiceTotalValue;
+use Landingi\BookkeepingBundle\Bookkeeping\InvoiceSummary;
+use Landingi\BookkeepingBundle\Bookkeeping\Language;
+use Landingi\BookkeepingBundle\Integration\IntegrationTestCase;
+use Landingi\BookkeepingBundle\Memory\Contractor\Company\ValueAddedTax\MemoryIdentifierFactory;
+use Landingi\BookkeepingBundle\Wfirma\Client\Credentials\WfirmaCredentials;
+use Landingi\BookkeepingBundle\Wfirma\Client\WfirmaClient;
+use Landingi\BookkeepingBundle\Wfirma\Client\WfirmaConditionTransformer;
+use Landingi\BookkeepingBundle\Wfirma\Contractor\Factory\ContractorFactory;
+use Landingi\BookkeepingBundle\Wfirma\Contractor\WfirmaContractorBook;
+use Landingi\BookkeepingBundle\Wfirma\Expense\Factory\ExpenseSummaryFactory;
+use Landingi\BookkeepingBundle\Wfirma\Expense\WfirmaExpenseBook;
+use Landingi\BookkeepingBundle\Wfirma\Invoice\Factory\InvoiceFactory;
+use Landingi\BookkeepingBundle\Wfirma\Invoice\Factory\InvoiceSummaryFactory;
+use Landingi\BookkeepingBundle\Wfirma\Invoice\InvoiceItem\WfirmaValueAddedTax;
+use Landingi\BookkeepingBundle\Wfirma\Invoice\WfirmaInvoiceBook;
+use Landingi\BookkeepingBundle\Wfirma\Invoice\WfirmaInvoiceItem;
+use Landingi\BookkeepingBundle\Wfirma\Invoice\WfirmaInvoiceItemCollection;
+use Landingi\BookkeepingBundle\Wfirma\WfirmaInvoice;
+
+final class WfirmaExpenseBookTest extends IntegrationTestCase
+{
+    private ExpenseBook $expenseBook;
+
+    public function setUp(): void
+    {
+        $client = new WfirmaClient(
+            new WfirmaCredentials(
+                (string) getenv('WFIRMA_API_LOGIN'),
+                (string) getenv('WFIRMA_API_PASSWORD'),
+                (int) getenv('WFIRMA_API_COMPANY')
+            ),
+            new WfirmaConditionTransformer()
+        );
+        $this->expenseBook = new WfirmaExpenseBook(
+            $client,
+            new ExpenseSummaryFactory(),
+        );
+    }
+
+    public function testItListsExpenseSummaries(): void
+    {
+        $conditions = [
+            new ExactExpenseDate(new \DateTimeImmutable('2023-05-15')),
+            new ExcludeExpenseSeries((string) 'foo'),
+        ];
+        $summaries = $this->expenseBook->listSummaries(1, ...$conditions);
+        $this->assertEquals(1, $summaryArray = $summaries->getAll());
+        /** @var ExpenseSummary $summary */
+        $summary = $summaryArray[0];
+        $this->assertEquals('EXP 1', $summary->getIdentifier());
+        $this->assertEquals(2137.00, $summary->getNetPlnValue()->toFloat());
+    }
+}

--- a/tests/Integration/Wfirma/Invoice/WfirmaExpenseBookTest.php
+++ b/tests/Integration/Wfirma/Invoice/WfirmaExpenseBookTest.php
@@ -41,7 +41,7 @@ final class WfirmaExpenseBookTest extends IntegrationTestCase
             new ExcludeExpenseSeries((string) 'foo'),
         ];
         $summaries = $this->expenseBook->listSummaries(1, ...$conditions);
-        $this->assertEquals(1, $summaryArray = $summaries->getAll());
+        $this->assertCount(1, $summaryArray = $summaries->getAll());
         /** @var ExpenseSummary $summary */
         $summary = $summaryArray[0];
         $this->assertEquals('EXP 1', $summary->getIdentifier());

--- a/tests/Integration/Wfirma/Invoice/WfirmaExpenseBookTest.php
+++ b/tests/Integration/Wfirma/Invoice/WfirmaExpenseBookTest.php
@@ -36,7 +36,7 @@ final class WfirmaExpenseBookTest extends IntegrationTestCase
 
     /**
      * The predefined expense in this test should be replaced with a created one, whenever
-     * the option to add an expense is added to the bundle
+     * the option to add an expense is added to the bundle.
      */
     public function testItListsExpenseSummaries(): void
     {

--- a/tests/Integration/Wfirma/Invoice/WfirmaExpenseBookTest.php
+++ b/tests/Integration/Wfirma/Invoice/WfirmaExpenseBookTest.php
@@ -3,54 +3,16 @@ declare(strict_types=1);
 
 namespace Landingi\BookkeepingBundle\Integration\Wfirma\Invoice;
 
-use DateTime;
-use Landingi\BookkeepingBundle\Bookkeeping\Contractor;
-use Landingi\BookkeepingBundle\Bookkeeping\Contractor\Address\City;
-use Landingi\BookkeepingBundle\Bookkeeping\Contractor\Address\Country;
-use Landingi\BookkeepingBundle\Bookkeeping\Contractor\Address\PostalCode;
-use Landingi\BookkeepingBundle\Bookkeeping\Contractor\Address\Street;
-use Landingi\BookkeepingBundle\Bookkeeping\Contractor\ContractorAddress;
-use Landingi\BookkeepingBundle\Bookkeeping\Contractor\ContractorEmail;
-use Landingi\BookkeepingBundle\Bookkeeping\Contractor\ContractorIdentifier;
-use Landingi\BookkeepingBundle\Bookkeeping\Contractor\ContractorName;
-use Landingi\BookkeepingBundle\Bookkeeping\Contractor\Person;
-use Landingi\BookkeepingBundle\Bookkeeping\Currency;
 use Landingi\BookkeepingBundle\Bookkeeping\Expense\Collection\Condition\ExactExpenseDate;
 use Landingi\BookkeepingBundle\Bookkeeping\Expense\Collection\Condition\ExcludeExpenseSeries;
 use Landingi\BookkeepingBundle\Bookkeeping\Expense\ExpenseBook;
 use Landingi\BookkeepingBundle\Bookkeeping\ExpenseSummary;
-use Landingi\BookkeepingBundle\Bookkeeping\Invoice\Collection\Condition\ExactDate;
-use Landingi\BookkeepingBundle\Bookkeeping\Invoice\Collection\Condition\ExcludeSeries;
-use Landingi\BookkeepingBundle\Bookkeeping\Invoice\Collection\Condition\IncludeSeries;
-use Landingi\BookkeepingBundle\Bookkeeping\Invoice\InvoiceBook;
-use Landingi\BookkeepingBundle\Bookkeeping\Invoice\InvoiceDescription;
-use Landingi\BookkeepingBundle\Bookkeeping\Invoice\InvoiceFullNumber;
-use Landingi\BookkeepingBundle\Bookkeeping\Invoice\InvoiceIdentifier;
-use Landingi\BookkeepingBundle\Bookkeeping\Invoice\InvoiceItem\Name;
-use Landingi\BookkeepingBundle\Bookkeeping\Invoice\InvoiceItem\NumberOfUnits;
-use Landingi\BookkeepingBundle\Bookkeeping\Invoice\InvoiceItem\Price;
-use Landingi\BookkeepingBundle\Bookkeeping\Invoice\InvoiceItem\ValueAddedTax;
-use Landingi\BookkeepingBundle\Bookkeeping\Invoice\InvoiceNetPlnValue;
-use Landingi\BookkeepingBundle\Bookkeeping\Invoice\InvoiceSeries;
-use Landingi\BookkeepingBundle\Bookkeeping\Invoice\InvoiceTotalValue;
-use Landingi\BookkeepingBundle\Bookkeeping\InvoiceSummary;
-use Landingi\BookkeepingBundle\Bookkeeping\Language;
 use Landingi\BookkeepingBundle\Integration\IntegrationTestCase;
-use Landingi\BookkeepingBundle\Memory\Contractor\Company\ValueAddedTax\MemoryIdentifierFactory;
 use Landingi\BookkeepingBundle\Wfirma\Client\Credentials\WfirmaCredentials;
 use Landingi\BookkeepingBundle\Wfirma\Client\WfirmaClient;
 use Landingi\BookkeepingBundle\Wfirma\Client\WfirmaConditionTransformer;
-use Landingi\BookkeepingBundle\Wfirma\Contractor\Factory\ContractorFactory;
-use Landingi\BookkeepingBundle\Wfirma\Contractor\WfirmaContractorBook;
 use Landingi\BookkeepingBundle\Wfirma\Expense\Factory\ExpenseSummaryFactory;
 use Landingi\BookkeepingBundle\Wfirma\Expense\WfirmaExpenseBook;
-use Landingi\BookkeepingBundle\Wfirma\Invoice\Factory\InvoiceFactory;
-use Landingi\BookkeepingBundle\Wfirma\Invoice\Factory\InvoiceSummaryFactory;
-use Landingi\BookkeepingBundle\Wfirma\Invoice\InvoiceItem\WfirmaValueAddedTax;
-use Landingi\BookkeepingBundle\Wfirma\Invoice\WfirmaInvoiceBook;
-use Landingi\BookkeepingBundle\Wfirma\Invoice\WfirmaInvoiceItem;
-use Landingi\BookkeepingBundle\Wfirma\Invoice\WfirmaInvoiceItemCollection;
-use Landingi\BookkeepingBundle\Wfirma\WfirmaInvoice;
 
 final class WfirmaExpenseBookTest extends IntegrationTestCase
 {

--- a/tests/Integration/Wfirma/Invoice/WfirmaInvoiceBookTest.php
+++ b/tests/Integration/Wfirma/Invoice/WfirmaInvoiceBookTest.php
@@ -134,8 +134,10 @@ final class WfirmaInvoiceBookTest extends IntegrationTestCase
             new ExcludeSeries((string) $invoice->getFullNumber()),
         ];
         $invoices = $this->invoiceBook->list(1, ...$conditions);
-        $this->assertEmpty(array_filter($invoices->getAll(), fn(Invoice $filterCandidate) =>
-            (string) $filterCandidate->getFullNumber() === (string) $invoice->getFullNumber()
+        $this->assertEmpty(array_filter(
+            $invoices->getAll(),
+            fn(Invoice $filterCandidate) =>
+                (string) $filterCandidate->getFullNumber() === (string) $invoice->getFullNumber()
         ));
 
         //test delete

--- a/tests/Integration/Wfirma/Invoice/WfirmaInvoiceBookTest.php
+++ b/tests/Integration/Wfirma/Invoice/WfirmaInvoiceBookTest.php
@@ -136,7 +136,7 @@ final class WfirmaInvoiceBookTest extends IntegrationTestCase
         $invoices = $this->invoiceBook->list(1, ...$conditions);
         $this->assertEmpty(array_filter(
             $invoices->getAll(),
-            fn(Invoice $result) => (string) $result->getFullNumber() === (string) $invoice->getFullNumber()
+            fn (Invoice $result) => (string) $result->getFullNumber() === (string) $invoice->getFullNumber()
         ));
 
         //test delete

--- a/tests/Integration/Wfirma/Invoice/WfirmaInvoiceBookTest.php
+++ b/tests/Integration/Wfirma/Invoice/WfirmaInvoiceBookTest.php
@@ -95,8 +95,8 @@ final class WfirmaInvoiceBookTest extends IntegrationTestCase
                 $contractor,
                 new Currency('PLN'),
                 $now = new DateTime(),
-                new DateTime(),
-                new DateTime(),
+                $now,
+                $now,
                 new Language('PL')
             )
         );
@@ -113,12 +113,12 @@ final class WfirmaInvoiceBookTest extends IntegrationTestCase
         //test list
         $conditions = [
             new ExactDate(\DateTimeImmutable::createFromMutable($now)),
-            new IncludeSeries((string) $invoice->getInvoiceSeries()->getIdentifier()),
+            new IncludeSeries((string) $invoice->getFullNumber()),
         ];
         $invoices = $this->invoiceBook->list(1, ...$conditions);
         $summaries = $this->invoiceBook->listSummaries(1, ...$conditions);
-        $this->assertGreaterThanOrEqual(1, $invoiceArray = $invoices->getAll());
-        $this->assertGreaterThanOrEqual(1, $summaryArray = $summaries->getAll());
+        $this->assertCount(1, $invoiceArray = $invoices->getAll());
+        $this->assertCount(1, $summaryArray = $summaries->getAll());
         /** @var WfirmaInvoice $lastInvoice */
         $lastInvoice = end($invoiceArray);
         /** @var InvoiceSummary $lastSummary */
@@ -130,7 +130,7 @@ final class WfirmaInvoiceBookTest extends IntegrationTestCase
         // test list excludes invoice
         $conditions = [
             new ExactDate(\DateTimeImmutable::createFromMutable($now)),
-            new ExcludeSeries((string) $invoice->getInvoiceSeries()->getIdentifier()),
+            new ExcludeSeries((string) $invoice->getFullNumber()),
         ];
         $invoices = $this->invoiceBook->list(1, ...$conditions);
         $this->assertCount(0, $invoices->getAll());

--- a/tests/Integration/Wfirma/Invoice/WfirmaInvoiceBookTest.php
+++ b/tests/Integration/Wfirma/Invoice/WfirmaInvoiceBookTest.php
@@ -123,7 +123,7 @@ final class WfirmaInvoiceBookTest extends IntegrationTestCase
         $lastInvoice = end($invoiceArray);
         /** @var InvoiceSummary $lastSummary */
         $lastSummary = end($summaryArray);
-        $this->assertEquals('test description - bundle invoice', $lastInvoice->getDescription());
+        $this->assertEquals('test description - bundle invoice', (string) $lastInvoice->getDescription());
         $this->assertEquals($invoice->getIdentifier(), $lastInvoice->getIdentifier());
         $this->assertEquals($invoice->getIdentifier(), $lastSummary->getIdentifier());
 

--- a/tests/Integration/Wfirma/Invoice/WfirmaInvoiceBookTest.php
+++ b/tests/Integration/Wfirma/Invoice/WfirmaInvoiceBookTest.php
@@ -136,8 +136,7 @@ final class WfirmaInvoiceBookTest extends IntegrationTestCase
         $invoices = $this->invoiceBook->list(1, ...$conditions);
         $this->assertEmpty(array_filter(
             $invoices->getAll(),
-            fn(Invoice $filterCandidate) =>
-                (string) $filterCandidate->getFullNumber() === (string) $invoice->getFullNumber()
+            fn(Invoice $result) => (string) $result->getFullNumber() === (string) $invoice->getFullNumber()
         ));
 
         //test delete

--- a/tests/Integration/Wfirma/Invoice/WfirmaInvoiceBookTest.php
+++ b/tests/Integration/Wfirma/Invoice/WfirmaInvoiceBookTest.php
@@ -15,6 +15,7 @@ use Landingi\BookkeepingBundle\Bookkeeping\Contractor\ContractorIdentifier;
 use Landingi\BookkeepingBundle\Bookkeeping\Contractor\ContractorName;
 use Landingi\BookkeepingBundle\Bookkeeping\Contractor\Person;
 use Landingi\BookkeepingBundle\Bookkeeping\Currency;
+use Landingi\BookkeepingBundle\Bookkeeping\Invoice;
 use Landingi\BookkeepingBundle\Bookkeeping\Invoice\Collection\Condition\ExactDate;
 use Landingi\BookkeepingBundle\Bookkeeping\Invoice\Collection\Condition\ExcludeSeries;
 use Landingi\BookkeepingBundle\Bookkeeping\Invoice\Collection\Condition\IncludeSeries;
@@ -133,7 +134,9 @@ final class WfirmaInvoiceBookTest extends IntegrationTestCase
             new ExcludeSeries((string) $invoice->getFullNumber()),
         ];
         $invoices = $this->invoiceBook->list(1, ...$conditions);
-        $this->assertCount(0, $invoices->getAll());
+        $this->assertEmpty(array_filter($invoices->getAll(), fn(Invoice $filterCandidate) =>
+            (string) $filterCandidate->getFullNumber() === (string) $invoice->getFullNumber()
+        ));
 
         //test delete
         $this->invoiceBook->delete($invoice->getIdentifier());

--- a/tests/Integration/Wfirma/Invoice/WfirmaInvoiceBookTest.php
+++ b/tests/Integration/Wfirma/Invoice/WfirmaInvoiceBookTest.php
@@ -79,7 +79,7 @@ final class WfirmaInvoiceBookTest extends IntegrationTestCase
         $invoice = $this->invoiceBook->create(
             new WfirmaInvoice(
                 new InvoiceIdentifier('123'),
-                $invoiceSeries = new InvoiceSeries(new InvoiceSeries\InvoiceSeriesIdentifier(0)),
+                new InvoiceSeries(new InvoiceSeries\InvoiceSeriesIdentifier(0)),
                 new InvoiceDescription('test description - bundle invoice'),
                 new InvoiceFullNumber('FV 69/2023'),
                 new InvoiceTotalValue(100),
@@ -113,7 +113,7 @@ final class WfirmaInvoiceBookTest extends IntegrationTestCase
         //test list
         $conditions = [
             new ExactDate(\DateTimeImmutable::createFromMutable($now)),
-            new IncludeSeries((string) $invoiceSeries->getIdentifier()),
+            new IncludeSeries((string) $invoice->getInvoiceSeries()->getIdentifier()),
         ];
         $invoices = $this->invoiceBook->list(1, ...$conditions);
         $summaries = $this->invoiceBook->listSummaries(1, ...$conditions);
@@ -130,7 +130,7 @@ final class WfirmaInvoiceBookTest extends IntegrationTestCase
         // test list excludes invoice
         $conditions = [
             new ExactDate(\DateTimeImmutable::createFromMutable($now)),
-            new ExcludeSeries((string) $invoiceSeries->getIdentifier()),
+            new ExcludeSeries((string) $invoice->getInvoiceSeries()->getIdentifier()),
         ];
         $invoices = $this->invoiceBook->list(1, ...$conditions);
         $this->assertCount(0, $invoices->getAll());

--- a/tests/Unit/Bookkeeping/Expense/ExpenseNetPlnValueTest.php
+++ b/tests/Unit/Bookkeeping/Expense/ExpenseNetPlnValueTest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Landingi\BookkeepingBundle\Unit\Bookkeeping\Expense;
+
+use Landingi\BookkeepingBundle\Bookkeeping\Expense\Exception\ExpenseException;
+use Landingi\BookkeepingBundle\Bookkeeping\Expense\ExpenseNetPlnValue;
+use PHPUnit\Framework\TestCase;
+
+class ExpenseNetPlnValueTest extends TestCase
+{
+    public function testThrowsOnZeroValue(): void
+    {
+        $this->expectException(ExpenseException::class);
+        (new ExpenseNetPlnValue(0));
+    }
+}

--- a/tests/Unit/Bookkeeping/ExpenseSummaryTest.php
+++ b/tests/Unit/Bookkeeping/ExpenseSummaryTest.php
@@ -19,5 +19,6 @@ class ExpenseSummaryTest extends TestCase
         );
         $this->assertEquals('123', (string) $summary->getIdentifier());
         $this->assertEquals(100.00, $summary->getNetPlnValue()->toFloat());
+        $this->assertEquals('100.00', (string) $summary->getNetPlnValue());
     }
 }

--- a/tests/Unit/Bookkeeping/ExpenseSummaryTest.php
+++ b/tests/Unit/Bookkeeping/ExpenseSummaryTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Landingi\BookkeepingBundle\Unit\Bookkeeping;
+
+use Landingi\BookkeepingBundle\Bookkeeping\Currency;
+use Landingi\BookkeepingBundle\Bookkeeping\Expense\ExpenseIdentifier;
+use Landingi\BookkeepingBundle\Bookkeeping\Expense\ExpenseNetPlnValue;
+use Landingi\BookkeepingBundle\Bookkeeping\ExpenseSummary;
+use Landingi\BookkeepingBundle\Bookkeeping\Invoice\InvoiceFullNumber;
+use Landingi\BookkeepingBundle\Bookkeeping\Invoice\InvoiceIdentifier;
+use Landingi\BookkeepingBundle\Bookkeeping\Invoice\InvoiceNetPlnValue;
+use Landingi\BookkeepingBundle\Bookkeeping\Invoice\InvoicePaymentMethod;
+use Landingi\BookkeepingBundle\Bookkeeping\Invoice\InvoiceTotalValue;
+use Landingi\BookkeepingBundle\Bookkeeping\InvoiceSummary;
+use PHPUnit\Framework\TestCase;
+
+class ExpenseSummaryTest extends TestCase
+{
+    public function testGettersReturnProperValues(): void
+    {
+        $summary = new ExpenseSummary(
+            new ExpenseIdentifier('123'),
+            new ExpenseNetPlnValue(10000),
+        );
+        $this->assertEquals('123', (string) $summary->getIdentifier());
+        $this->assertEquals(100.00, $summary->getNetPlnValue()->toFloat());
+    }
+}

--- a/tests/Unit/Bookkeeping/ExpenseSummaryTest.php
+++ b/tests/Unit/Bookkeeping/ExpenseSummaryTest.php
@@ -4,16 +4,9 @@ declare(strict_types=1);
 
 namespace Landingi\BookkeepingBundle\Unit\Bookkeeping;
 
-use Landingi\BookkeepingBundle\Bookkeeping\Currency;
 use Landingi\BookkeepingBundle\Bookkeeping\Expense\ExpenseIdentifier;
 use Landingi\BookkeepingBundle\Bookkeeping\Expense\ExpenseNetPlnValue;
 use Landingi\BookkeepingBundle\Bookkeeping\ExpenseSummary;
-use Landingi\BookkeepingBundle\Bookkeeping\Invoice\InvoiceFullNumber;
-use Landingi\BookkeepingBundle\Bookkeeping\Invoice\InvoiceIdentifier;
-use Landingi\BookkeepingBundle\Bookkeeping\Invoice\InvoiceNetPlnValue;
-use Landingi\BookkeepingBundle\Bookkeeping\Invoice\InvoicePaymentMethod;
-use Landingi\BookkeepingBundle\Bookkeeping\Invoice\InvoiceTotalValue;
-use Landingi\BookkeepingBundle\Bookkeeping\InvoiceSummary;
 use PHPUnit\Framework\TestCase;
 
 class ExpenseSummaryTest extends TestCase

--- a/tests/Unit/Bookkeeping/ExpenseSummaryTest.php
+++ b/tests/Unit/Bookkeeping/ExpenseSummaryTest.php
@@ -19,6 +19,6 @@ class ExpenseSummaryTest extends TestCase
         );
         $this->assertEquals('123', (string) $summary->getIdentifier());
         $this->assertEquals(100.00, $summary->getNetPlnValue()->toFloat());
-        $this->assertEquals('100.00', (string) $summary->getNetPlnValue());
+        $this->assertEquals('100', (string) $summary->getNetPlnValue());
     }
 }

--- a/tests/Unit/Wfirma/Client/Request/Expenses/FindExpensesTest.php
+++ b/tests/Unit/Wfirma/Client/Request/Expenses/FindExpensesTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Landingi\BookkeepingBundle\Unit\Wfirma\Client\Request\Expenses;
+
+use Landingi\BookkeepingBundle\Wfirma\Client\Request\Expenses\FindExpenses;
+use PHPUnit\Framework\TestCase;
+
+class FindExpensesTest extends TestCase
+{
+    public function testGetContentGeneratesExpectedXml(): void
+    {
+        $request = new FindExpenses(
+            $conditionXml = '<condition></condition>',
+            $page = 14
+        );
+        $this->assertEquals(
+            <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<api>
+    <expenses>
+        <parameters>
+            <conditions>
+                <and>
+                    $conditionXml   
+                </and>
+            </conditions>
+            <page>$page</page>
+        </parameters>
+    </expenses>
+</api>
+XML,
+            $request->getContent()
+        );
+        $this->assertEquals($request->getContent(), (string) $request);
+    }
+}

--- a/tests/Unit/Wfirma/Client/WfirmaConditionTransformerTest.php
+++ b/tests/Unit/Wfirma/Client/WfirmaConditionTransformerTest.php
@@ -9,10 +9,10 @@ use Landingi\BookkeepingBundle\Bookkeeping\Collection\CollectionCondition;
 use Landingi\BookkeepingBundle\Bookkeeping\Expense\Collection\Condition\ExactExpenseDate;
 use Landingi\BookkeepingBundle\Bookkeeping\Expense\Collection\Condition\ExcludeExpenseSeries;
 use Landingi\BookkeepingBundle\Bookkeeping\Expense\Collection\ExpenseCondition;
-use Landingi\BookkeepingBundle\Bookkeeping\Invoice\Collection\InvoiceCondition;
 use Landingi\BookkeepingBundle\Bookkeeping\Invoice\Collection\Condition\ExactDate;
 use Landingi\BookkeepingBundle\Bookkeeping\Invoice\Collection\Condition\ExcludeSeries;
 use Landingi\BookkeepingBundle\Bookkeeping\Invoice\Collection\Condition\IncludeSeries;
+use Landingi\BookkeepingBundle\Bookkeeping\Invoice\Collection\InvoiceCondition;
 use Landingi\BookkeepingBundle\Wfirma\Client\WfirmaConditionTransformer;
 use PHPUnit\Framework\TestCase;
 
@@ -109,7 +109,7 @@ XML
                     return '';
                 }
             },
-            'Provided collection condition is not supported'
+            'Provided collection condition is not supported',
         ];
         yield 'Invoice condition' => [
             new class() implements InvoiceCondition {
@@ -118,7 +118,7 @@ XML
                     return '';
                 }
             },
-            'Provided invoice condition is not supported'
+            'Provided invoice condition is not supported',
         ];
         yield 'Expense condition' => [
             new class() implements ExpenseCondition {
@@ -127,7 +127,7 @@ XML
                     return '';
                 }
             },
-            'Provided expense condition is not supported'
+            'Provided expense condition is not supported',
         ];
     }
 }

--- a/tests/Unit/Wfirma/Client/WfirmaConditionTransformerTest.php
+++ b/tests/Unit/Wfirma/Client/WfirmaConditionTransformerTest.php
@@ -5,7 +5,11 @@ declare(strict_types=1);
 namespace Landingi\BookkeepingBundle\Unit\Wfirma\Client;
 
 use InvalidArgumentException;
-use Landingi\BookkeepingBundle\Bookkeeping\Invoice\Collection\Condition;
+use Landingi\BookkeepingBundle\Bookkeeping\Collection\CollectionCondition;
+use Landingi\BookkeepingBundle\Bookkeeping\Expense\Collection\Condition\ExactExpenseDate;
+use Landingi\BookkeepingBundle\Bookkeeping\Expense\Collection\Condition\ExcludeExpenseSeries;
+use Landingi\BookkeepingBundle\Bookkeeping\Expense\Collection\ExpenseCondition;
+use Landingi\BookkeepingBundle\Bookkeeping\Invoice\Collection\InvoiceCondition;
 use Landingi\BookkeepingBundle\Bookkeeping\Invoice\Collection\Condition\ExactDate;
 use Landingi\BookkeepingBundle\Bookkeeping\Invoice\Collection\Condition\ExcludeSeries;
 use Landingi\BookkeepingBundle\Bookkeeping\Invoice\Collection\Condition\IncludeSeries;
@@ -21,59 +25,109 @@ class WfirmaConditionTransformerTest extends TestCase
         $this->transformer = new WfirmaConditionTransformer();
     }
 
-    public function testToXmlTransformsExactDateCondition(): void
+    /**
+     * @dataProvider provideValidCondition
+     */
+    public function testToXmlTransformsConditions(CollectionCondition $condition, string $expectedXml): void
     {
-        $datetime = new \DateTimeImmutable('now');
-        $this->assertEquals(
+        $this->assertEquals($expectedXml, $this->transformer->toXml($condition));
+    }
+
+    public function provideValidCondition(): \Generator
+    {
+        $now = new \DateTimeImmutable('now');
+
+        yield 'Invoice exact date condition' => [
+            new ExactDate($now),
             <<<XML
 <condition>
     <field>date</field>
     <operator>eq</operator>
-    <value>{$datetime->format('Y-m-d')}</value>
+    <value>{$now->format('Y-m-d')}</value>
 </condition>
-XML,
-            $this->transformer->toXml(new ExactDate($datetime))
-        );
-    }
-
-    public function testToXmlTransformsIncludeSeriesCondition(): void
-    {
-        $this->assertEquals(
+XML
+        ];
+        yield 'Invoice include series condition' => [
+            new IncludeSeries('foo'),
             <<<XML
 <condition>
     <field>fullnumber</field>
     <operator>like</operator>
     <value>%foo%</value>
 </condition>
-XML,
-            $this->transformer->toXml(new IncludeSeries('foo'))
-        );
-    }
-
-    public function testToXmlTransformsExcludeSeriesCondition(): void
-    {
-        $this->assertEquals(
+XML
+        ];
+        yield 'Invoice exclude series condition' => [
+            new ExcludeSeries('foo'),
             <<<XML
 <condition>
     <field>fullnumber</field>
     <operator>not like</operator>
     <value>%foo%</value>
 </condition>
-XML,
-            $this->transformer->toXml(new ExcludeSeries('foo'))
-        );
+XML
+        ];
+        yield 'Expense exact date condition' => [
+            new ExactExpenseDate($now),
+            <<<XML
+<condition>
+    <field>date</field>
+    <operator>eq</operator>
+    <value>{$now->format('Y-m-d')}</value>
+</condition>
+XML
+        ];
+        yield 'Expense exclude series date condition' => [
+            new ExcludeExpenseSeries('foo'),
+            <<<XML
+<condition>
+    <field>fullnumber</field>
+    <operator>not like</operator>
+    <value>%foo%</value>
+</condition>
+XML
+        ];
     }
 
-    public function testOtherConditionThrowsException(): void
+    /**
+     * @dataProvider provideInvalidCondition
+     */
+    public function testOtherConditionThrowsException(CollectionCondition $condition, string $expectedMessage): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Provided condition is not supported');
+        $this->expectExceptionMessage($expectedMessage);
 
-        $this->transformer->toXml(new class() implements Condition {
-            public function __toString(): string
-            {
-                return '';
-            }
-        });
+        $this->transformer->toXml($condition);
+    }
+
+    public function provideInvalidCondition(): \Generator
+    {
+        yield 'Generic condition' => [
+            new class() implements CollectionCondition {
+                public function __toString(): string
+                {
+                    return '';
+                }
+            },
+            'Provided collection condition is not supported'
+        ];
+        yield 'Invoice condition' => [
+            new class() implements InvoiceCondition {
+                public function __toString(): string
+                {
+                    return '';
+                }
+            },
+            'Provided invoice condition is not supported'
+        ];
+        yield 'Expense condition' => [
+            new class() implements ExpenseCondition {
+                public function __toString(): string
+                {
+                    return '';
+                }
+            },
+            'Provided expense condition is not supported'
+        ];
     }
 }


### PR DESCRIPTION
Add an `ExpenseBook` interface, with Wfirma implementation. The only method is `listSummaries`, which has a similar signature to `InvoiceBook::listSummaries`.
It returns a `Collection` of `ExpenseSummary` objects, each of which has the `ExpenseIdentifier` and `ExpenseNetPlnValue` fields.