### PR TITLE
Add exact invoice `fullnumber` condition to use in InvoiceBook

### DIFF
--- a/src/Bookkeeping/Invoice/Collection/Condition/ExactInvoiceNumber.php
+++ b/src/Bookkeeping/Invoice/Collection/Condition/ExactInvoiceNumber.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Landingi\BookkeepingBundle\Bookkeeping\Invoice\Collection\Condition;
+
+use Landingi\BookkeepingBundle\Bookkeeping\Invoice\Collection\InvoiceCondition;
+
+final class ExactInvoiceNumber implements InvoiceCondition
+{
+    private string $invoiceNumber;
+
+    /**
+     * This accepts an invoice's full number to compare against.
+     */
+    public function __construct(string $invoiceNumber)
+    {
+        $this->invoiceNumber = $invoiceNumber;
+    }
+
+    public function __toString(): string
+    {
+        return $this->invoiceNumber;
+    }
+}

--- a/src/Wfirma/Client/WfirmaConditionTransformer.php
+++ b/src/Wfirma/Client/WfirmaConditionTransformer.php
@@ -10,6 +10,7 @@ use Landingi\BookkeepingBundle\Bookkeeping\Expense\Collection\Condition\ExactExp
 use Landingi\BookkeepingBundle\Bookkeeping\Expense\Collection\Condition\ExcludeExpenseSeries;
 use Landingi\BookkeepingBundle\Bookkeeping\Expense\Collection\ExpenseCondition;
 use Landingi\BookkeepingBundle\Bookkeeping\Invoice\Collection\Condition\ExactDate;
+use Landingi\BookkeepingBundle\Bookkeeping\Invoice\Collection\Condition\ExactInvoiceNumber;
 use Landingi\BookkeepingBundle\Bookkeeping\Invoice\Collection\Condition\ExcludeSeries;
 use Landingi\BookkeepingBundle\Bookkeeping\Invoice\Collection\Condition\IncludeSeries;
 use Landingi\BookkeepingBundle\Bookkeeping\Invoice\Collection\InvoiceCondition;
@@ -33,6 +34,10 @@ final class WfirmaConditionTransformer
     {
         if ($condition instanceof ExactDate) {
             return $this->buildExactDateXml($condition);
+        }
+
+        if ($condition instanceof ExactInvoiceNumber) {
+            return $this->buildExactNumberXml($condition);
         }
 
         if ($condition instanceof IncludeSeries) {
@@ -64,6 +69,17 @@ final class WfirmaConditionTransformer
         return <<<XML
 <condition>
     <field>date</field>
+    <operator>eq</operator>
+    <value>{$condition}</value>
+</condition>
+XML;
+    }
+
+    private function buildExactNumberXml(CollectionCondition $condition): string
+    {
+        return <<<XML
+<condition>
+    <field>fullnumber</field>
     <operator>eq</operator>
     <value>{$condition}</value>
 </condition>

--- a/tests/Unit/Bookkeeping/Invoice/Collection/Condition/ExactInvoiceNumberTest.php
+++ b/tests/Unit/Bookkeeping/Invoice/Collection/Condition/ExactInvoiceNumberTest.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Landingi\BookkeepingBundle\Unit\Bookkeeping\Invoice\Collection\Condition;
+
+use Landingi\BookkeepingBundle\Bookkeeping\Invoice\Collection\Condition\ExactInvoiceNumber;
+use PHPUnit\Framework\TestCase;
+
+class ExactInvoiceNumberTest extends TestCase
+{
+    public function testToString(): void
+    {
+        $this->assertEquals('FV foo', (string) new ExactInvoiceNumber('FV foo'));
+    }
+}

--- a/tests/Unit/Wfirma/Client/WfirmaConditionTransformerTest.php
+++ b/tests/Unit/Wfirma/Client/WfirmaConditionTransformerTest.php
@@ -10,6 +10,7 @@ use Landingi\BookkeepingBundle\Bookkeeping\Expense\Collection\Condition\ExactExp
 use Landingi\BookkeepingBundle\Bookkeeping\Expense\Collection\Condition\ExcludeExpenseSeries;
 use Landingi\BookkeepingBundle\Bookkeeping\Expense\Collection\ExpenseCondition;
 use Landingi\BookkeepingBundle\Bookkeeping\Invoice\Collection\Condition\ExactDate;
+use Landingi\BookkeepingBundle\Bookkeeping\Invoice\Collection\Condition\ExactInvoiceNumber;
 use Landingi\BookkeepingBundle\Bookkeeping\Invoice\Collection\Condition\ExcludeSeries;
 use Landingi\BookkeepingBundle\Bookkeeping\Invoice\Collection\Condition\IncludeSeries;
 use Landingi\BookkeepingBundle\Bookkeeping\Invoice\Collection\InvoiceCondition;
@@ -44,6 +45,16 @@ class WfirmaConditionTransformerTest extends TestCase
     <field>date</field>
     <operator>eq</operator>
     <value>{$now->format('Y-m-d')}</value>
+</condition>
+XML
+        ];
+        yield 'Invoice exact number condition' => [
+            new ExactInvoiceNumber('FV foo'),
+            <<<XML
+<condition>
+    <field>fullnumber</field>
+    <operator>eq</operator>
+    <value>FV foo</value>
 </condition>
 XML
         ];


### PR DESCRIPTION
This will allow us to find an invoice by its exact number, instead of using a "like" comparison (as in the  `IncludeSeries` condition).