### PR TITLE
[BC]Change wFirma authorization method

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -13,9 +13,10 @@ jobs:
             matrix:
                 php-version: [ '7.4', '8.0' ]
         env:
-            WFIRMA_API_COMPANY: ${{ secrets.WFIRMA_API_COMPANY }}
-            WFIRMA_API_LOGIN: ${{ secrets.WFIRMA_API_LOGIN }}
-            WFIRMA_API_PASSWORD: ${{ secrets.WFIRMA_API_PASSWORD }}
+            WFIRMA_API_COMPANY_ID: ${{ secrets.WFIRMA_API_COMPANY }}
+            WFIRMA_API_ACCESS_KEY: ${{ secrets.WFIRMA_API_ACCESS_KEY }}
+            WFIRMA_API_SECRET_KEY: ${{ secrets.WFIRMA_API_SECRET_KEY }}
+            WFIRMA_API_APP_KEY: ${{ secrets.WFIRMA_API_APP_KEY }}
         steps:
             -   name: Checkout
                 uses: actions/checkout@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,6 +12,9 @@ jobs:
             max-parallel: 1
             matrix:
                 php-version: [ '7.4', '8.0' ]
+        concurrency:
+            group: ci-tests-${{ github.ref }}
+            cancel-in-progress: true
         env:
             WFIRMA_API_COMPANY_ID: ${{ secrets.WFIRMA_API_COMPANY }}
             WFIRMA_API_ACCESS_KEY: ${{ secrets.WFIRMA_API_ACCESS_KEY }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,9 +13,10 @@ jobs:
             matrix:
                 php-version: [ '7.4', '8.0' ]
         env:
-            WFIRMA_API_COMPANY: ${{ secrets.WFIRMA_API_COMPANY }}
-            WFIRMA_API_LOGIN: ${{ secrets.WFIRMA_API_LOGIN }}
-            WFIRMA_API_PASSWORD: ${{ secrets.WFIRMA_API_PASSWORD }}
+            WFIRMA_API_COMPANY_ID: ${{ secrets.WFIRMA_API_COMPANY }}
+            WFIRMA_API_ACCESS_KEY: ${{ secrets.WFIRMA_API_ACCESS_KEY }}
+            WFIRMA_API_SECRET_KEY: ${{ secrets.WFIRMA_API_SECRET_KEY }}
+            WFIRMA_API_APP_KEY: ${{ secrets.WFIRMA_API_APP_KEY }}
         steps:
             -   name: Checkout
                 uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -11,9 +11,21 @@
 composer require landingi/bookkeeping-bundle
 ```
 
+To use the wFirma implementation, configure the `WfirmaClient` service, specifically provide the necessary credentials
+for the `WfirmaCredentials` class as well as the API host URL (for example `https://api2.wfirma.pl`) for the `WfirmaApiUrl` class.
+
+### v4+
+Starting with version 4.0.0 we no longer use a login/password credential schema, and instead we switched to the following:
+
+- accessKey
+- secretKey
+- appKey
+
+See the wFirma API documentation below for more details.
+
 ## Development
 
 ### Additional
 
-* [Wfirma API documentation](https://doc.wfirma.pl)
+* [wFirma API documentation](https://doc.wfirma.pl)
 * [Documentation](docs/README.md)

--- a/src/Curl/Curl.php
+++ b/src/Curl/Curl.php
@@ -21,7 +21,7 @@ final class Curl
     {
         $curl = new self($url);
         $curl->setOpt(CURLOPT_HTTPHEADER, array_map(
-            fn($key, $value) => "$key: $value",
+            fn ($key, $value) => "$key: $value",
             array_keys($headers),
             array_values($headers)
         ));

--- a/src/Curl/Curl.php
+++ b/src/Curl/Curl.php
@@ -19,6 +19,7 @@ final class Curl
      */
     public static function withHeaderAuth(string $url, array $headers): self
     {
+        var_dump($url);
         $curl = new self($url);
         $curl->setOpt(CURLOPT_HTTPHEADER, array_map(
             fn ($key, $value) => "$key: $value",

--- a/src/Curl/Curl.php
+++ b/src/Curl/Curl.php
@@ -81,7 +81,7 @@ final class Curl
     /**
      * @throws \Landingi\BookkeepingBundle\Curl\CurlException
      */
-    private function setOpt($option, $value): void
+    private function setOpt(int $option, $value): void
     {
         if (false === curl_setopt($this->curl, $option, $value)) {
             throw new CurlException(
@@ -100,9 +100,9 @@ final class Curl
     private function exec(): string
     {
         $response = curl_exec($this->curl);
-        var_dump($response);
+
         if (false === $response) {
-            throw new CurlException('cURL error: ' . curl_error($this->curl));
+            throw new CurlException(sprintf('cURL error %s: %s', curl_errno($this->curl), curl_error($this->curl)));
         }
 
         return (string) $response;

--- a/src/Curl/Curl.php
+++ b/src/Curl/Curl.php
@@ -100,7 +100,7 @@ final class Curl
     private function exec(): string
     {
         $response = curl_exec($this->curl);
-var_dump($response);
+        var_dump($response);
         if (false === $response) {
             throw new CurlException('cURL error: ' . curl_error($this->curl));
         }

--- a/src/Curl/Curl.php
+++ b/src/Curl/Curl.php
@@ -19,7 +19,6 @@ final class Curl
      */
     public static function withHeaderAuth(string $url, array $headers): self
     {
-        var_dump($url);
         $curl = new self($url);
         $curl->setOpt(CURLOPT_HTTPHEADER, array_map(
             fn ($key, $value) => "$key: $value",

--- a/src/Curl/Curl.php
+++ b/src/Curl/Curl.php
@@ -17,10 +17,14 @@ final class Curl
     /**
      * @throws CurlException
      */
-    public static function withBasicAuth(string $url, string $credentials): self
+    public static function withHeaderAuth(string $url, array $headers): self
     {
         $curl = new self($url);
-        $curl->setOpt(CURLOPT_USERPWD, $credentials);
+        $curl->setOpt(CURLOPT_HTTPHEADER, array_map(
+            fn($key, $value) => "$key: $value",
+            array_keys($headers),
+            array_values($headers)
+        ));
 
         return $curl;
     }

--- a/src/Curl/Curl.php
+++ b/src/Curl/Curl.php
@@ -100,11 +100,11 @@ final class Curl
     private function exec(): string
     {
         $response = curl_exec($this->curl);
-
+var_dump($response);
         if (false === $response) {
             throw new CurlException('cURL error: ' . curl_error($this->curl));
         }
 
-        return $response;
+        return (string) $response;
     }
 }

--- a/src/Wfirma/Client/Credentials/WfirmaCredentials.php
+++ b/src/Wfirma/Client/Credentials/WfirmaCredentials.php
@@ -7,25 +7,26 @@ use function sprintf;
 
 final class WfirmaCredentials
 {
-    private string $login;
-    private string $password;
+    private string $accessKey;
+    private string $secretKey;
+    private string $appKey;
     private int $companyId;
 
-    public function __construct(string $login, string $password, int $companyId)
+    public function __construct(string $accessKey, string $secretKey, string $appKey, int $companyId)
     {
-        $this->login = $login;
-        $this->password = $password;
+        $this->accessKey = $accessKey;
+        $this->secretKey = $secretKey;
+        $this->appKey = $appKey;
         $this->companyId = $companyId;
     }
 
-    public function toString(): string
+    public function asHeaders(): array
     {
-        return sprintf('%s:%s', $this->login, $this->password);
-    }
-
-    public function __toString(): string
-    {
-        return $this->toString();
+        return [
+            'accessKey' => $this->accessKey,
+            'secretKey' => $this->secretKey,
+            'appKey' => $this->appKey,
+        ];
     }
 
     public function getCompanyId(): int

--- a/src/Wfirma/Client/Credentials/WfirmaCredentials.php
+++ b/src/Wfirma/Client/Credentials/WfirmaCredentials.php
@@ -3,8 +3,6 @@ declare(strict_types=1);
 
 namespace Landingi\BookkeepingBundle\Wfirma\Client\Credentials;
 
-use function sprintf;
-
 final class WfirmaCredentials
 {
     private string $accessKey;

--- a/src/Wfirma/Client/WfirmaApiUrl.php
+++ b/src/Wfirma/Client/WfirmaApiUrl.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Landingi\BookkeepingBundle\Wfirma\Client;
+
+final class WfirmaApiUrl
+{
+    private string $wfirmaUrl;
+
+    public function __construct(string $wfirmaUrl)
+    {
+        $this->wfirmaUrl = $wfirmaUrl;
+    }
+
+    public function __toString(): string
+    {
+        return $this->wfirmaUrl;
+    }
+}

--- a/src/Wfirma/Client/WfirmaClient.php
+++ b/src/Wfirma/Client/WfirmaClient.php
@@ -21,14 +21,16 @@ use function sprintf;
 
 final class WfirmaClient
 {
-    private const API = 'https://api2.wfirma.pl';
+    private WfirmaApiUrl $wfirmaApiUrl;
     private WfirmaCredentials $credentials;
     private WfirmaConditionTransformer $conditionTransformer;
 
     public function __construct(
+        WfirmaApiUrl $wfirmaApiUrl,
         WfirmaCredentials $credentials,
         WfirmaConditionTransformer $conditionTransformer
     ) {
+        $this->wfirmaApiUrl = $wfirmaApiUrl;
         $this->credentials = $credentials;
         $this->conditionTransformer = $conditionTransformer;
     }
@@ -179,14 +181,14 @@ final class WfirmaClient
 
     private function getCurl(string $url): Curl
     {
-        return Curl::withBasicAuth(
+        return Curl::withHeaderAuth(
             sprintf(
                 '%s/%s?company_id=%d&inputFormat=xml&outputFormat=json',
-                self::API,
+                $this->wfirmaApiUrl,
                 $url,
                 $this->credentials->getCompanyId()
             ),
-            $this->credentials->toString()
+            $this->credentials->asHeaders()
         );
     }
 

--- a/tests/Integration/Wfirma/Contractor/WfirmaContractorBookTest.php
+++ b/tests/Integration/Wfirma/Contractor/WfirmaContractorBookTest.php
@@ -11,6 +11,7 @@ use Landingi\BookkeepingBundle\Bookkeeping\Contractor\Person;
 use Landingi\BookkeepingBundle\Integration\IntegrationTestCase;
 use Landingi\BookkeepingBundle\Memory\Contractor\Company\ValueAddedTax\MemoryIdentifierFactory;
 use Landingi\BookkeepingBundle\Wfirma\Client\Credentials\WfirmaCredentials;
+use Landingi\BookkeepingBundle\Wfirma\Client\WfirmaApiUrl;
 use Landingi\BookkeepingBundle\Wfirma\Client\WfirmaClient;
 use Landingi\BookkeepingBundle\Wfirma\Client\WfirmaConditionTransformer;
 use Landingi\BookkeepingBundle\Wfirma\Contractor\Factory\ContractorFactory;
@@ -24,10 +25,12 @@ final class WfirmaContractorBookTest extends IntegrationTestCase
     {
         $this->book = new WfirmaContractorBook(
             new WfirmaClient(
+                new WfirmaApiUrl((string) getenv('WFIRMA_API_URL')),
                 new WfirmaCredentials(
-                    (string) getenv('WFIRMA_API_LOGIN'),
-                    (string) getenv('WFIRMA_API_PASSWORD'),
-                    (int) getenv('WFIRMA_API_COMPANY')
+                    (string) getenv('WFIRMA_API_ACCESS_KEY'),
+                    (string) getenv('WFIRMA_API_SECRET_KEY'),
+                    (string) getenv('WFIRMA_API_APP_KEY'),
+                    (int) getenv('WFIRMA_API_COMPANY_ID')
                 ),
                 new WfirmaConditionTransformer()
             ),

--- a/tests/Integration/Wfirma/Invoice/CreateInvoiceTest.php
+++ b/tests/Integration/Wfirma/Invoice/CreateInvoiceTest.php
@@ -56,7 +56,6 @@ final class CreateInvoiceTest extends IntegrationTestCase
 
     public function setUp(): void
     {
-        var_dump(getenv('WFIRMA_API_URL'));
         $client = new WfirmaClient(
             new WfirmaApiUrl((string) getenv('WFIRMA_API_URL')),
             new WfirmaCredentials(

--- a/tests/Integration/Wfirma/Invoice/CreateInvoiceTest.php
+++ b/tests/Integration/Wfirma/Invoice/CreateInvoiceTest.php
@@ -34,6 +34,7 @@ use Landingi\BookkeepingBundle\Bookkeeping\Language;
 use Landingi\BookkeepingBundle\Integration\IntegrationTestCase;
 use Landingi\BookkeepingBundle\Memory\Contractor\Company\ValueAddedTax\MemoryIdentifierFactory;
 use Landingi\BookkeepingBundle\Wfirma\Client\Credentials\WfirmaCredentials;
+use Landingi\BookkeepingBundle\Wfirma\Client\WfirmaApiUrl;
 use Landingi\BookkeepingBundle\Wfirma\Client\WfirmaClient;
 use Landingi\BookkeepingBundle\Wfirma\Client\WfirmaConditionTransformer;
 use Landingi\BookkeepingBundle\Wfirma\Contractor\Factory\ContractorFactory;
@@ -56,10 +57,12 @@ final class CreateInvoiceTest extends IntegrationTestCase
     public function setUp(): void
     {
         $client = new WfirmaClient(
+            new WfirmaApiUrl((string) getenv('WFIRMA_API_URL')),
             new WfirmaCredentials(
-                (string) getenv('WFIRMA_API_LOGIN'),
-                (string) getenv('WFIRMA_API_PASSWORD'),
-                (int) getenv('WFIRMA_API_COMPANY')
+                (string) getenv('WFIRMA_API_ACCESS_KEY'),
+                (string) getenv('WFIRMA_API_SECRET_KEY'),
+                (string) getenv('WFIRMA_API_APP_KEY'),
+                (int) getenv('WFIRMA_API_COMPANY_ID')
             ),
             new WfirmaConditionTransformer()
         );

--- a/tests/Integration/Wfirma/Invoice/CreateInvoiceTest.php
+++ b/tests/Integration/Wfirma/Invoice/CreateInvoiceTest.php
@@ -56,7 +56,7 @@ final class CreateInvoiceTest extends IntegrationTestCase
 
     public function setUp(): void
     {
-        var_dump((string) getenv('WFIRMA_API_URL'));
+        var_dump(getenv('WFIRMA_API_URL'));
         $client = new WfirmaClient(
             new WfirmaApiUrl((string) getenv('WFIRMA_API_URL')),
             new WfirmaCredentials(

--- a/tests/Integration/Wfirma/Invoice/CreateInvoiceTest.php
+++ b/tests/Integration/Wfirma/Invoice/CreateInvoiceTest.php
@@ -56,6 +56,7 @@ final class CreateInvoiceTest extends IntegrationTestCase
 
     public function setUp(): void
     {
+        var_dump((string) getenv('WFIRMA_API_URL'));
         $client = new WfirmaClient(
             new WfirmaApiUrl((string) getenv('WFIRMA_API_URL')),
             new WfirmaCredentials(

--- a/tests/Integration/Wfirma/Invoice/DownloadInvoiceTest.php
+++ b/tests/Integration/Wfirma/Invoice/DownloadInvoiceTest.php
@@ -33,6 +33,7 @@ use Landingi\BookkeepingBundle\Integration\IntegrationTestCase;
 use Landingi\BookkeepingBundle\Memory\Contractor\Company\ValueAddedTax\MemoryIdentifierFactory;
 use Landingi\BookkeepingBundle\Wfirma\Client\Credentials\WfirmaCredentials;
 use Landingi\BookkeepingBundle\Wfirma\Client\Exception\NotFoundException;
+use Landingi\BookkeepingBundle\Wfirma\Client\WfirmaApiUrl;
 use Landingi\BookkeepingBundle\Wfirma\Client\WfirmaClient;
 use Landingi\BookkeepingBundle\Wfirma\Client\WfirmaConditionTransformer;
 use Landingi\BookkeepingBundle\Wfirma\Contractor\Factory\ContractorFactory;
@@ -54,10 +55,12 @@ class DownloadInvoiceTest extends IntegrationTestCase
     public function setUp(): void
     {
         $client = new WfirmaClient(
+            new WfirmaApiUrl((string) getenv('WFIRMA_API_URL')),
             new WfirmaCredentials(
-                (string) getenv('WFIRMA_API_LOGIN'),
-                (string) getenv('WFIRMA_API_PASSWORD'),
-                (int) getenv('WFIRMA_API_COMPANY')
+                (string) getenv('WFIRMA_API_ACCESS_KEY'),
+                (string) getenv('WFIRMA_API_SECRET_KEY'),
+                (string) getenv('WFIRMA_API_APP_KEY'),
+                (int) getenv('WFIRMA_API_COMPANY_ID')
             ),
             new WfirmaConditionTransformer()
         );

--- a/tests/Integration/Wfirma/Invoice/WfirmaExpenseBookTest.php
+++ b/tests/Integration/Wfirma/Invoice/WfirmaExpenseBookTest.php
@@ -9,6 +9,7 @@ use Landingi\BookkeepingBundle\Bookkeeping\Expense\ExpenseBook;
 use Landingi\BookkeepingBundle\Bookkeeping\ExpenseSummary;
 use Landingi\BookkeepingBundle\Integration\IntegrationTestCase;
 use Landingi\BookkeepingBundle\Wfirma\Client\Credentials\WfirmaCredentials;
+use Landingi\BookkeepingBundle\Wfirma\Client\WfirmaApiUrl;
 use Landingi\BookkeepingBundle\Wfirma\Client\WfirmaClient;
 use Landingi\BookkeepingBundle\Wfirma\Client\WfirmaConditionTransformer;
 use Landingi\BookkeepingBundle\Wfirma\Expense\Factory\ExpenseSummaryFactory;
@@ -21,10 +22,12 @@ final class WfirmaExpenseBookTest extends IntegrationTestCase
     public function setUp(): void
     {
         $client = new WfirmaClient(
+            new WfirmaApiUrl((string) getenv('WFIRMA_API_URL')),
             new WfirmaCredentials(
-                (string) getenv('WFIRMA_API_LOGIN'),
-                (string) getenv('WFIRMA_API_PASSWORD'),
-                (int) getenv('WFIRMA_API_COMPANY')
+                (string) getenv('WFIRMA_API_ACCESS_KEY'),
+                (string) getenv('WFIRMA_API_SECRET_KEY'),
+                (string) getenv('WFIRMA_API_APP_KEY'),
+                (int) getenv('WFIRMA_API_COMPANY_ID')
             ),
             new WfirmaConditionTransformer()
         );

--- a/tests/Integration/Wfirma/Invoice/WfirmaInvoiceBookTest.php
+++ b/tests/Integration/Wfirma/Invoice/WfirmaInvoiceBookTest.php
@@ -35,6 +35,7 @@ use Landingi\BookkeepingBundle\Bookkeeping\Language;
 use Landingi\BookkeepingBundle\Integration\IntegrationTestCase;
 use Landingi\BookkeepingBundle\Memory\Contractor\Company\ValueAddedTax\MemoryIdentifierFactory;
 use Landingi\BookkeepingBundle\Wfirma\Client\Credentials\WfirmaCredentials;
+use Landingi\BookkeepingBundle\Wfirma\Client\WfirmaApiUrl;
 use Landingi\BookkeepingBundle\Wfirma\Client\WfirmaClient;
 use Landingi\BookkeepingBundle\Wfirma\Client\WfirmaConditionTransformer;
 use Landingi\BookkeepingBundle\Wfirma\Contractor\Factory\ContractorFactory;
@@ -55,10 +56,12 @@ final class WfirmaInvoiceBookTest extends IntegrationTestCase
     public function setUp(): void
     {
         $client = new WfirmaClient(
+            new WfirmaApiUrl((string) getenv('WFIRMA_API_URL')),
             new WfirmaCredentials(
-                (string) getenv('WFIRMA_API_LOGIN'),
-                (string) getenv('WFIRMA_API_PASSWORD'),
-                (int) getenv('WFIRMA_API_COMPANY')
+                (string) getenv('WFIRMA_API_ACCESS_KEY'),
+                (string) getenv('WFIRMA_API_SECRET_KEY'),
+                (string) getenv('WFIRMA_API_APP_KEY'),
+                (int) getenv('WFIRMA_API_COMPANY_ID')
             ),
             new WfirmaConditionTransformer()
         );

--- a/tests/Integration/Wfirma/WfirmaClientTest.php
+++ b/tests/Integration/Wfirma/WfirmaClientTest.php
@@ -5,6 +5,7 @@ namespace Landingi\BookkeepingBundle\Integration\Wfirma;
 
 use Landingi\BookkeepingBundle\Integration\IntegrationTestCase;
 use Landingi\BookkeepingBundle\Wfirma\Client\Credentials\WfirmaCredentials;
+use Landingi\BookkeepingBundle\Wfirma\Client\WfirmaApiUrl;
 use Landingi\BookkeepingBundle\Wfirma\Client\WfirmaClient;
 use Landingi\BookkeepingBundle\Wfirma\Client\WfirmaClientException;
 use Landingi\BookkeepingBundle\Wfirma\Client\WfirmaConditionTransformer;
@@ -16,10 +17,12 @@ final class WfirmaClientTest extends IntegrationTestCase
     public function setUp(): void
     {
         $this->client = new WfirmaClient(
+            new WfirmaApiUrl((string) getenv('WFIRMA_API_URL')),
             new WfirmaCredentials(
-                (string) getenv('WFIRMA_API_LOGIN'),
-                (string) getenv('WFIRMA_API_PASSWORD'),
-                (int) getenv('WFIRMA_API_COMPANY')
+                (string) getenv('WFIRMA_API_ACCESS_KEY'),
+                (string) getenv('WFIRMA_API_SECRET_KEY'),
+                (string) getenv('WFIRMA_API_APP_KEY'),
+                (int) getenv('WFIRMA_API_COMPANY_ID')
             ),
             new WfirmaConditionTransformer()
         );


### PR DESCRIPTION
Due to imminent changes in the wFirma API, the authorization system has been refactored to use an API key scheme, instead of the login/password one used in previous API versions.