### PR TITLE
Catch invalid NIP exception in wFirma contractor book 

### DIFF
--- a/src/Bookkeeping/Contractor/Exception/InvalidVatIdException.php
+++ b/src/Bookkeeping/Contractor/Exception/InvalidVatIdException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Landingi\BookkeepingBundle\Bookkeeping\Contractor\Exception;
+
+use RuntimeException;
+
+final class InvalidVatIdException extends RuntimeException
+{
+}

--- a/src/Wfirma/Client/Exception/ErrorResponseException.php
+++ b/src/Wfirma/Client/Exception/ErrorResponseException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Landingi\BookkeepingBundle\Wfirma\Client\Exception;
+
+use Landingi\BookkeepingBundle\Wfirma\Client\WfirmaClientException;
+
+final class ErrorResponseException extends WfirmaClientException
+{
+    public function __construct(string $url, array $result, string $request)
+    {
+        parent::__construct($url, $result, $request, 'External system returns an error');
+    }
+}

--- a/src/Wfirma/Client/WfirmaClient.php
+++ b/src/Wfirma/Client/WfirmaClient.php
@@ -3,11 +3,14 @@ declare(strict_types=1);
 
 namespace Landingi\BookkeepingBundle\Wfirma\Client;
 
+use JsonException;
 use Landingi\BookkeepingBundle\Bookkeeping\Expense\Collection\ExpenseCondition;
 use Landingi\BookkeepingBundle\Bookkeeping\Invoice\Collection\InvoiceCondition;
 use Landingi\BookkeepingBundle\Curl\Curl;
+use Landingi\BookkeepingBundle\Curl\CurlException;
 use Landingi\BookkeepingBundle\Wfirma\Client\Credentials\WfirmaCredentials;
 use Landingi\BookkeepingBundle\Wfirma\Client\Exception\AuthorizationException;
+use Landingi\BookkeepingBundle\Wfirma\Client\Exception\ErrorResponseException;
 use Landingi\BookkeepingBundle\Wfirma\Client\Exception\FatalException;
 use Landingi\BookkeepingBundle\Wfirma\Client\Exception\NotFoundException;
 use Landingi\BookkeepingBundle\Wfirma\Client\Exception\OutOfServiceException;
@@ -36,14 +39,15 @@ final class WfirmaClient
     }
 
     /**
-     * @throws \JsonException
-     * @throws \Landingi\BookkeepingBundle\Curl\CurlException
-     * @throws \Landingi\BookkeepingBundle\Wfirma\Client\Exception\AuthorizationException
-     * @throws \Landingi\BookkeepingBundle\Wfirma\Client\Exception\FatalException
-     * @throws \Landingi\BookkeepingBundle\Wfirma\Client\Exception\NotFoundException
-     * @throws \Landingi\BookkeepingBundle\Wfirma\Client\Exception\OutOfServiceException
-     * @throws \Landingi\BookkeepingBundle\Wfirma\Client\Exception\TotalRequestsLimitExceededException
-     * @throws \Landingi\BookkeepingBundle\Wfirma\Client\Exception\TotalExecutionTimeLimitExceededException
+     * @throws JsonException
+     * @throws CurlException
+     * @throws AuthorizationException
+     * @throws FatalException
+     * @throws NotFoundException
+     * @throws OutOfServiceException
+     * @throws TotalRequestsLimitExceededException
+     * @throws TotalExecutionTimeLimitExceededException
+     * @throws ErrorResponseException
      */
     public function requestGET(string $url): array
     {
@@ -51,14 +55,15 @@ final class WfirmaClient
     }
 
     /**
-     * @throws \JsonException
-     * @throws \Landingi\BookkeepingBundle\Curl\CurlException
-     * @throws \Landingi\BookkeepingBundle\Wfirma\Client\Exception\AuthorizationException
-     * @throws \Landingi\BookkeepingBundle\Wfirma\Client\Exception\FatalException
-     * @throws \Landingi\BookkeepingBundle\Wfirma\Client\Exception\NotFoundException
-     * @throws \Landingi\BookkeepingBundle\Wfirma\Client\Exception\OutOfServiceException
-     * @throws \Landingi\BookkeepingBundle\Wfirma\Client\Exception\TotalRequestsLimitExceededException
-     * @throws \Landingi\BookkeepingBundle\Wfirma\Client\Exception\TotalExecutionTimeLimitExceededException
+     * @throws JsonException
+     * @throws CurlException
+     * @throws AuthorizationException
+     * @throws FatalException
+     * @throws NotFoundException
+     * @throws OutOfServiceException
+     * @throws TotalRequestsLimitExceededException
+     * @throws TotalExecutionTimeLimitExceededException
+     * @throws ErrorResponseException
      */
     public function requestPOST(string $url, string $data): array
     {
@@ -66,14 +71,15 @@ final class WfirmaClient
     }
 
     /**
-     * @throws \JsonException
-     * @throws \Landingi\BookkeepingBundle\Curl\CurlException
-     * @throws \Landingi\BookkeepingBundle\Wfirma\Client\Exception\AuthorizationException
-     * @throws \Landingi\BookkeepingBundle\Wfirma\Client\Exception\FatalException
-     * @throws \Landingi\BookkeepingBundle\Wfirma\Client\Exception\NotFoundException
-     * @throws \Landingi\BookkeepingBundle\Wfirma\Client\Exception\OutOfServiceException
-     * @throws \Landingi\BookkeepingBundle\Wfirma\Client\Exception\TotalRequestsLimitExceededException
-     * @throws \Landingi\BookkeepingBundle\Wfirma\Client\Exception\TotalExecutionTimeLimitExceededException
+     * @throws JsonException
+     * @throws CurlException
+     * @throws AuthorizationException
+     * @throws FatalException
+     * @throws NotFoundException
+     * @throws OutOfServiceException
+     * @throws TotalRequestsLimitExceededException
+     * @throws TotalExecutionTimeLimitExceededException
+     * @throws ErrorResponseException
      */
     public function requestDELETE(string $url): array
     {
@@ -81,15 +87,15 @@ final class WfirmaClient
     }
 
     /**
-     * @throws \JsonException
-     * @throws \Landingi\BookkeepingBundle\Curl\CurlException
-     * @throws \Landingi\BookkeepingBundle\Wfirma\Client\Exception\AuthorizationException
-     * @throws \Landingi\BookkeepingBundle\Wfirma\Client\Exception\FatalException
-     * @throws \Landingi\BookkeepingBundle\Wfirma\Client\Exception\NotFoundException
-     * @throws \Landingi\BookkeepingBundle\Wfirma\Client\Exception\OutOfServiceException
-     * @throws \Landingi\BookkeepingBundle\Wfirma\Client\Exception\TotalRequestsLimitExceededException
-     * @throws \Landingi\BookkeepingBundle\Wfirma\Client\Exception\TotalExecutionTimeLimitExceededException
-     * @throws \Landingi\BookkeepingBundle\Wfirma\Client\WfirmaClientException
+     * @throws JsonException
+     * @throws CurlException
+     * @throws AuthorizationException
+     * @throws FatalException
+     * @throws NotFoundException
+     * @throws OutOfServiceException
+     * @throws TotalRequestsLimitExceededException
+     * @throws TotalExecutionTimeLimitExceededException
+     * @throws WfirmaClientException
      */
     public function getVatId(string $countryCode, int $vatRate): int
     {
@@ -135,10 +141,10 @@ final class WfirmaClient
     }
 
     /**
-     * @throws \JsonException
-     * @throws \Landingi\BookkeepingBundle\Curl\CurlException
-     * @throws \Landingi\BookkeepingBundle\Wfirma\Client\Exception\NotFoundException
-     * @throws \Landingi\BookkeepingBundle\Wfirma\Client\WfirmaClientException
+     * @throws JsonException
+     * @throws CurlException
+     * @throws NotFoundException
+     * @throws WfirmaClientException
      */
     public function requestInvoiceDownload(string $url): string
     {
@@ -179,6 +185,9 @@ final class WfirmaClient
         ));
     }
 
+    /**
+     * @throws CurlException
+     */
     private function getCurl(string $url): Curl
     {
         return Curl::withHeaderAuth(
@@ -193,12 +202,13 @@ final class WfirmaClient
     }
 
     /**
-     * @throws \Landingi\BookkeepingBundle\Wfirma\Client\Exception\AuthorizationException
-     * @throws \Landingi\BookkeepingBundle\Wfirma\Client\Exception\FatalException
-     * @throws \Landingi\BookkeepingBundle\Wfirma\Client\Exception\NotFoundException
-     * @throws \Landingi\BookkeepingBundle\Wfirma\Client\Exception\OutOfServiceException
-     * @throws \Landingi\BookkeepingBundle\Wfirma\Client\Exception\TotalRequestsLimitExceededException
-     * @throws \Landingi\BookkeepingBundle\Wfirma\Client\Exception\TotalExecutionTimeLimitExceededException
+     * @throws AuthorizationException
+     * @throws FatalException
+     * @throws NotFoundException
+     * @throws OutOfServiceException
+     * @throws TotalRequestsLimitExceededException
+     * @throws TotalExecutionTimeLimitExceededException
+     * @throws ErrorResponseException
      */
     private function handleResponse(array $result, string $url, string $data = ''): array
     {
@@ -216,15 +226,16 @@ final class WfirmaClient
                 throw new TotalExecutionTimeLimitExceededException($url, $result, $data);
             case 'TOTAL REQUESTS LIMIT EXCEEDED':
                 throw new TotalRequestsLimitExceededException($url, $result, $data);
-            case 'FATAL':
             case 'ERROR':
+                throw new ErrorResponseException($url, $result, $data);
+            case 'FATAL':
             default:
                 throw new FatalException($url, $result, $data);
         }
     }
 
     /**
-     * @throws \Landingi\BookkeepingBundle\Wfirma\Client\Exception\NotFoundException
+     * @throws NotFoundException
      */
     private function handleFileResponse(string $result, string $url, string $data = ''): string
     {

--- a/src/Wfirma/Contractor/WfirmaContractorBook.php
+++ b/src/Wfirma/Contractor/WfirmaContractorBook.php
@@ -134,7 +134,7 @@ final class WfirmaContractorBook implements ContractorBook
                 case 'nip':
                     throw new InvalidVatIdException($error['message'] ?: 'Invalid Vat Id provided');
                 default:
-                    // To be determined
+                    // Do nothing
             }
         }
     }

--- a/tests/Integration/Wfirma/Contractor/Resources/companies_invalid.json
+++ b/tests/Integration/Wfirma/Contractor/Resources/companies_invalid.json
@@ -1,0 +1,14 @@
+{
+    "companies": [
+        {
+            "id": "1234",
+            "name": "Polish Company",
+            "email": "polish.company@gmail.com",
+            "street": "Witkiewicza",
+            "zip": "44-100",
+            "city": "Gliwice",
+            "country": "PL",
+            "nip": "12345678"
+        }
+    ]
+}

--- a/tests/Integration/Wfirma/Contractor/WfirmaContractorBookTest.php
+++ b/tests/Integration/Wfirma/Contractor/WfirmaContractorBookTest.php
@@ -111,4 +111,28 @@ final class WfirmaContractorBookTest extends IntegrationTestCase
             yield [$factory->getContractor($company)];
         }
     }
+
+    public function testErrorResponseThrowsException(Contractor $company, string $exceptionClass): void
+    {
+        $this->expectException($exceptionClass);
+        $this->book->create($company);
+    }
+
+    /**
+     * @internal use only in testErrorResponseThrowsException function
+     */
+    public function invalidCompanies(): Generator
+    {
+        $factory = new ContractorFactory(new MemoryIdentifierFactory());
+        $data = json_decode(
+            (string) file_get_contents(__DIR__ . '/Resources/companies_invalid.json'),
+            true,
+            512,
+            JSON_THROW_ON_ERROR
+        );
+
+        foreach ($data['companies'] as $company) {
+            yield [$factory->getContractor($company)];
+        }
+    }
 }

--- a/tests/Integration/Wfirma/Contractor/WfirmaContractorBookTest.php
+++ b/tests/Integration/Wfirma/Contractor/WfirmaContractorBookTest.php
@@ -8,6 +8,7 @@ use Landingi\BookkeepingBundle\Bookkeeping\Contractor;
 use Landingi\BookkeepingBundle\Bookkeeping\Contractor\Company;
 use Landingi\BookkeepingBundle\Bookkeeping\Contractor\ContractorBook;
 use Landingi\BookkeepingBundle\Bookkeeping\Contractor\ContractorEmail;
+use Landingi\BookkeepingBundle\Bookkeeping\Contractor\Exception\InvalidVatIdException;
 use Landingi\BookkeepingBundle\Bookkeeping\Contractor\Person;
 use Landingi\BookkeepingBundle\Integration\IntegrationTestCase;
 use Landingi\BookkeepingBundle\Memory\Contractor\Company\ValueAddedTax\MemoryIdentifierFactory;
@@ -17,6 +18,7 @@ use Landingi\BookkeepingBundle\Wfirma\Client\WfirmaClient;
 use Landingi\BookkeepingBundle\Wfirma\Client\WfirmaConditionTransformer;
 use Landingi\BookkeepingBundle\Wfirma\Contractor\Factory\ContractorFactory;
 use Landingi\BookkeepingBundle\Wfirma\Contractor\WfirmaContractorBook;
+use Throwable;
 
 final class WfirmaContractorBookTest extends IntegrationTestCase
 {
@@ -112,6 +114,12 @@ final class WfirmaContractorBookTest extends IntegrationTestCase
         }
     }
 
+    /**
+     * @dataProvider invalidCompanies
+     *
+     * @param Contractor $company
+     * @param class-string<Throwable> $exceptionClass
+     */
     public function testErrorResponseThrowsException(Contractor $company, string $exceptionClass): void
     {
         $this->expectException($exceptionClass);
@@ -132,7 +140,7 @@ final class WfirmaContractorBookTest extends IntegrationTestCase
         );
 
         foreach ($data['companies'] as $company) {
-            yield [$factory->getContractor($company)];
+            yield [$factory->getContractor($company), InvalidVatIdException::class];
         }
     }
 }


### PR DESCRIPTION
This can be used to throw a specific exception when the contractor NIP (PL Vat Id) is invalid and wFirma returns an error response.