### PR TITLE
Catch Invalid NIP error and throw when updating contractor

### DIFF
--- a/src/Bookkeeping/Contractor/Company.php
+++ b/src/Bookkeeping/Contractor/Company.php
@@ -84,4 +84,9 @@ final class Company implements Contractor
     {
         return $this->address->getCountry()->isEuropeanUnion();
     }
+
+    public function changeValueAddedTaxIdentifier(ValueAddedTaxIdentifier $identifier): void
+    {
+        $this->valueAddedTaxIdentifier = $identifier;
+    }
 }

--- a/src/Bookkeeping/Contractor/ContractorBook.php
+++ b/src/Bookkeeping/Contractor/ContractorBook.php
@@ -4,11 +4,22 @@ declare(strict_types=1);
 namespace Landingi\BookkeepingBundle\Bookkeeping\Contractor;
 
 use Landingi\BookkeepingBundle\Bookkeeping\Contractor;
+use Landingi\BookkeepingBundle\Bookkeeping\Contractor\Exception\InvalidVatIdException;
 
 interface ContractorBook
 {
     public function find(ContractorIdentifier $identifier): Contractor;
+
+    /**
+     * @throws InvalidVatIdException
+     * @throws ContractorException
+     */
     public function create(Contractor $contractor): Contractor;
     public function delete(ContractorIdentifier $identifier): void;
+
+    /**
+     * @throws InvalidVatIdException
+     * @throws ContractorException
+     */
     public function update(Contractor $contractor): Contractor;
 }

--- a/src/Bookkeeping/Contractor/Exception/InvalidVatIdException.php
+++ b/src/Bookkeeping/Contractor/Exception/InvalidVatIdException.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Landingi\BookkeepingBundle\Bookkeeping\Contractor\Exception;
 
-use RuntimeException;
+use Landingi\BookkeepingBundle\Bookkeeping\Contractor\ContractorException;
 
-final class InvalidVatIdException extends RuntimeException
+final class InvalidVatIdException extends ContractorException
 {
 }

--- a/src/Wfirma/Contractor/WfirmaContractorBook.php
+++ b/src/Wfirma/Contractor/WfirmaContractorBook.php
@@ -74,6 +74,7 @@ final class WfirmaContractorBook implements ContractorBook
      * @throws OutOfServiceException
      * @throws TotalExecutionTimeLimitExceededException
      * @throws TotalRequestsLimitExceededException
+     *
      * @return Contractor
      */
     public function create(Contractor $contractor): Contractor
@@ -130,6 +131,7 @@ final class WfirmaContractorBook implements ContractorBook
      * @throws TotalExecutionTimeLimitExceededException
      * @throws TotalRequestsLimitExceededException
      * @throws WfirmaException
+     *
      * @return Contractor
      */
     public function update(Contractor $contractor): Contractor

--- a/src/Wfirma/Contractor/WfirmaContractorBook.php
+++ b/src/Wfirma/Contractor/WfirmaContractorBook.php
@@ -8,8 +8,16 @@ use Landingi\BookkeepingBundle\Bookkeeping\Contractor;
 use Landingi\BookkeepingBundle\Bookkeeping\Contractor\ContractorBook;
 use Landingi\BookkeepingBundle\Bookkeeping\Contractor\ContractorException;
 use Landingi\BookkeepingBundle\Bookkeeping\Contractor\ContractorIdentifier;
+use Landingi\BookkeepingBundle\Bookkeeping\Contractor\Exception\InvalidEmailAddressException;
 use Landingi\BookkeepingBundle\Bookkeeping\Contractor\Exception\InvalidVatIdException;
+use Landingi\BookkeepingBundle\Curl\CurlException;
+use Landingi\BookkeepingBundle\Wfirma\Client\Exception\AuthorizationException;
 use Landingi\BookkeepingBundle\Wfirma\Client\Exception\ErrorResponseException;
+use Landingi\BookkeepingBundle\Wfirma\Client\Exception\FatalException;
+use Landingi\BookkeepingBundle\Wfirma\Client\Exception\NotFoundException;
+use Landingi\BookkeepingBundle\Wfirma\Client\Exception\OutOfServiceException;
+use Landingi\BookkeepingBundle\Wfirma\Client\Exception\TotalExecutionTimeLimitExceededException;
+use Landingi\BookkeepingBundle\Wfirma\Client\Exception\TotalRequestsLimitExceededException;
 use Landingi\BookkeepingBundle\Wfirma\Client\WfirmaClient;
 use Landingi\BookkeepingBundle\Wfirma\Client\WfirmaClientException;
 use Landingi\BookkeepingBundle\Wfirma\Contractor\Factory\ContractorFactory;
@@ -54,9 +62,19 @@ final class WfirmaContractorBook implements ContractorBook
     }
 
     /**
-     * @throws WfirmaException
      * @throws ContractorException
+     * @throws InvalidEmailAddressException
+     * @throws ErrorResponseException
      * @throws JsonException
+     * @throws WfirmaException
+     * @throws CurlException
+     * @throws AuthorizationException
+     * @throws FatalException
+     * @throws NotFoundException
+     * @throws OutOfServiceException
+     * @throws TotalExecutionTimeLimitExceededException
+     * @throws TotalRequestsLimitExceededException
+     * @return Contractor
      */
     public function create(Contractor $contractor): Contractor
     {
@@ -98,6 +116,22 @@ final class WfirmaContractorBook implements ContractorBook
         );
     }
 
+    /**
+     * @throws AuthorizationException
+     * @throws ContractorException
+     * @throws CurlException
+     * @throws ErrorResponseException
+     * @throws FatalException
+     * @throws InvalidEmailAddressException
+     * @throws InvalidVatIdException
+     * @throws JsonException
+     * @throws NotFoundException
+     * @throws OutOfServiceException
+     * @throws TotalExecutionTimeLimitExceededException
+     * @throws TotalRequestsLimitExceededException
+     * @throws WfirmaException
+     * @return Contractor
+     */
     public function update(Contractor $contractor): Contractor
     {
         try {

--- a/tests/Integration/Wfirma/Contractor/WfirmaContractorBookTest.php
+++ b/tests/Integration/Wfirma/Contractor/WfirmaContractorBookTest.php
@@ -120,14 +120,26 @@ final class WfirmaContractorBookTest extends IntegrationTestCase
      * @param Contractor $company
      * @param class-string<Throwable> $exceptionClass
      */
-    public function testErrorResponseThrowsException(Contractor $company, string $exceptionClass): void
+    public function testCreateErrorResponseThrowsException(Contractor $company, string $exceptionClass): void
     {
         $this->expectException($exceptionClass);
         $this->book->create($company);
     }
 
     /**
-     * @internal use only in testErrorResponseThrowsException function
+     * @dataProvider invalidCompanies
+     *
+     * @param Contractor $company
+     * @param class-string<Throwable> $exceptionClass
+     */
+    public function testUpdateErrorResponseThrowsException(Contractor $company, string $exceptionClass): void
+    {
+        $this->expectException($exceptionClass);
+        $this->book->update($company);
+    }
+
+    /**
+     * @internal use only in testErrorResponseThrowsException and testUpdateErrorResponseThrowsException functions
      */
     public function invalidCompanies(): Generator
     {


### PR DESCRIPTION
This is based on the WfirmaContractorBook changes introduced in the [4.2.0](https://github.com/landingi/bookkeeping-bundle/releases/tag/v4.2.0) release.