### PR TITLE
Use proper alpha-2 country code for Greece when printing contractor

### DIFF
--- a/src/Bookkeeping/Contractor/Address/Country.php
+++ b/src/Bookkeeping/Contractor/Address/Country.php
@@ -10,7 +10,7 @@ use function strlen;
 final class Country
 {
     /**
-     * The EU uses EL for Greece for VAT purposes, even though it's Alpha-2 code is GR
+     * The EU uses EL for Greece for VAT purposes, even though it's Alpha-2 code is GR.
      */
     private const EU_VAT_CODE_TO_ALPHA2 = [
         'EL' => 'GR',
@@ -61,7 +61,7 @@ final class Country
     }
 
     /**
-     * This may return different results than toString(), specifically for Greece
+     * This may return different results than toString(), specifically for Greece.
      */
     public function getAlpha2Code(): string
     {

--- a/src/Bookkeeping/Contractor/Address/Country.php
+++ b/src/Bookkeeping/Contractor/Address/Country.php
@@ -9,7 +9,14 @@ use function strlen;
 
 final class Country
 {
-    private const EUROPEAN_UNION_COUNTRIES = [
+    /**
+     * The EU uses EL for Greece for VAT purposes, even though it's Alpha-2 code is GR
+     */
+    private const EU_VAT_CODE_TO_ALPHA2 = [
+        'EL' => 'GR',
+    ];
+
+    private const EUROPEAN_UNION_VAT_COUNTRIES = [
         'AT',
         'BE',
         'BG',
@@ -53,14 +60,17 @@ final class Country
         $this->alpha2Code = $alpha2Code;
     }
 
+    /**
+     * This may return different results than toString(), specifically for Greece
+     */
     public function getAlpha2Code(): string
     {
-        return $this->alpha2Code;
+        return self::EU_VAT_CODE_TO_ALPHA2[$this->alpha2Code] ?? $this->alpha2Code;
     }
 
     public function isEuropeanUnion(): bool
     {
-        return in_array($this->alpha2Code, self::EUROPEAN_UNION_COUNTRIES);
+        return in_array($this->alpha2Code, self::EUROPEAN_UNION_VAT_COUNTRIES);
     }
 
     public function isPoland(): bool

--- a/src/Bookkeeping/Contractor/Company.php
+++ b/src/Bookkeeping/Contractor/Company.php
@@ -38,7 +38,7 @@ final class Company implements Contractor
         $contractor->with('street', $this->address->getStreet()->toString());
         $contractor->with('zip', $this->address->getPostalCode()->toString());
         $contractor->with('city', $this->address->getCity()->toString());
-        $contractor->with('country', $this->address->getCountry()->toString());
+        $contractor->with('country', $this->address->getCountry()->getAlpha2Code());
         $contractor->with('email', $this->email->toString());
 
         if ($this->address->getCountry()->isPoland()) {

--- a/src/Bookkeeping/Contractor/Person.php
+++ b/src/Bookkeeping/Contractor/Person.php
@@ -34,7 +34,7 @@ final class Person implements Contractor
         $contractor->with('street', $this->address->getStreet()->toString());
         $contractor->with('zip', $this->address->getPostalCode()->toString());
         $contractor->with('city', $this->address->getCity()->toString());
-        $contractor->with('country', $this->address->getCountry()->toString());
+        $contractor->with('country', $this->address->getCountry()->getAlpha2Code());
         $contractor->with('email', $this->email->toString());
 
         return $media;

--- a/tests/Unit/Bookkeeping/Contractor/CompanyTest.php
+++ b/tests/Unit/Bookkeeping/Contractor/CompanyTest.php
@@ -32,7 +32,7 @@ final class CompanyTest extends TestCase
             ),
             new ValueAddedTax\SimpleIdentifier('id')
         );
-        self::assertTrue($company->isPolish());
+        $this->assertTrue($company->isPolish());
         $company = new Company(
             new ContractorIdentifier('id'),
             new ContractorName('name'),
@@ -45,7 +45,7 @@ final class CompanyTest extends TestCase
             ),
             new ValueAddedTax\SimpleIdentifier('id')
         );
-        self::assertFalse($company->isPolish());
+        $this->assertFalse($company->isPolish());
     }
 
     public function testItIsEuropeanUnionCitizen(): void
@@ -62,7 +62,7 @@ final class CompanyTest extends TestCase
             ),
             new ValueAddedTax\SimpleIdentifier('id')
         );
-        self::assertFalse($company->isEuropeanUnionCitizen());
+        $this->assertFalse($company->isEuropeanUnionCitizen());
     }
 
     public function testItIsEuropeanUnionCompany(): void
@@ -79,7 +79,7 @@ final class CompanyTest extends TestCase
             ),
             new ValueAddedTax\SimpleIdentifier('id')
         );
-        self::assertTrue($company->isEuropeanUnionCompany());
+        $this->assertTrue($company->isEuropeanUnionCompany());
         $company = new Company(
             new ContractorIdentifier('id'),
             new ContractorName('name'),
@@ -92,7 +92,7 @@ final class CompanyTest extends TestCase
             ),
             new ValueAddedTax\SimpleIdentifier('id')
         );
-        self::assertFalse($company->isEuropeanUnionCompany());
+        $this->assertFalse($company->isEuropeanUnionCompany());
     }
 
     public function testItPrintsPolishCompany(): void
@@ -110,7 +110,7 @@ final class CompanyTest extends TestCase
             new ValueAddedTax\SimpleIdentifier('333444555')
         );
 
-        self::assertXmlStringEqualsXmlString(
+        $this->assertXmlStringEqualsXmlString(
             <<<XML
 <?xml version="1.0" encoding="UTF-8"?>
 <api>
@@ -148,7 +148,7 @@ XML,
             new ValueAddedTax\SimpleIdentifier('333444555')
         );
 
-        self::assertXmlStringEqualsXmlString(
+        $this->assertXmlStringEqualsXmlString(
             <<<XML
 <?xml version="1.0" encoding="UTF-8"?>
 <api>
@@ -160,6 +160,44 @@ XML,
             <zip>postal</zip>
             <city>city</city>
             <country>DE</country>
+            <email>name@foo.bar</email>
+            <tax_id_type>vat</tax_id_type>
+            <nip>333444555</nip>
+        </contractor>
+    </contractors>
+</api>
+XML,
+            $company->print(WfirmaMedia::api())->toString()
+        );
+    }
+
+    public function testItPrintsGreekCompany(): void
+    {
+        $company = new Company(
+            new ContractorIdentifier('id'),
+            new ContractorName('name'),
+            new ContractorEmail('name@foo.bar'),
+            new ContractorAddress(
+                new Street('street'),
+                new PostalCode('postal'),
+                new City('city'),
+                new Country('EL')
+            ),
+            new ValueAddedTax\SimpleIdentifier('333444555')
+        );
+
+        $this->assertXmlStringEqualsXmlString(
+            <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<api>
+    <contractors>
+        <contractor>
+            <name>name</name>
+            <altname>name</altname>
+            <street>street</street>
+            <zip>postal</zip>
+            <city>city</city>
+            <country>GR</country>
             <email>name@foo.bar</email>
             <tax_id_type>vat</tax_id_type>
             <nip>333444555</nip>
@@ -186,7 +224,7 @@ XML,
             new ValueAddedTax\SimpleIdentifier('333444555')
         );
 
-        self::assertXmlStringEqualsXmlString(
+        $this->assertXmlStringEqualsXmlString(
             <<<XML
 <?xml version="1.0" encoding="UTF-8"?>
 <api>

--- a/tests/Unit/Bookkeeping/Contractor/PersonTest.php
+++ b/tests/Unit/Bookkeeping/Contractor/PersonTest.php
@@ -30,7 +30,7 @@ final class PersonTest extends TestCase
                 new Country('PL')
             )
         );
-        self::assertTrue($person->isPolish());
+        $this->assertTrue($person->isPolish());
         $person = new Person(
             new ContractorIdentifier('id'),
             new ContractorName('name'),
@@ -42,7 +42,7 @@ final class PersonTest extends TestCase
                 new Country('US')
             )
         );
-        self::assertFalse($person->isPolish());
+        $this->assertFalse($person->isPolish());
     }
 
     public function testItIsEuropeanUnionCitizen(): void
@@ -58,7 +58,7 @@ final class PersonTest extends TestCase
                 new Country('PL')
             )
         );
-        self::assertTrue($person->isEuropeanUnionCitizen());
+        $this->assertTrue($person->isEuropeanUnionCitizen());
         $person = new Person(
             new ContractorIdentifier('id'),
             new ContractorName('name'),
@@ -70,7 +70,7 @@ final class PersonTest extends TestCase
                 new Country('US')
             )
         );
-        self::assertFalse($person->isEuropeanUnionCitizen());
+        $this->assertFalse($person->isEuropeanUnionCitizen());
     }
 
     public function testItIsEuropeanUnionCompany(): void
@@ -86,7 +86,7 @@ final class PersonTest extends TestCase
                 new Country('PL')
             )
         );
-        self::assertFalse($person->isEuropeanUnionCompany());
+        $this->assertFalse($person->isEuropeanUnionCompany());
     }
 
     public function testItPrints(): void
@@ -103,7 +103,7 @@ final class PersonTest extends TestCase
             )
         );
 
-        self::assertXmlStringEqualsXmlString(
+        $this->assertXmlStringEqualsXmlString(
             <<<XML
 <?xml version="1.0" encoding="UTF-8"?>
 <api>
@@ -122,5 +122,52 @@ final class PersonTest extends TestCase
 XML,
             $person->print(WfirmaMedia::api())->toString()
         );
+    }
+
+    public function testItPrintsGreekCitizen(): void
+    {
+        $person = new Person(
+            new ContractorIdentifier('id'),
+            new ContractorName('name'),
+            new ContractorEmail('name@foo.bar'),
+            new ContractorAddress(
+                new Street('street'),
+                new PostalCode('postal'),
+                new City('city'),
+                new Country('EL')
+            )
+        );
+        $anotherPerson = new Person(
+            new ContractorIdentifier('id'),
+            new ContractorName('name'),
+            new ContractorEmail('name@foo.bar'),
+            new ContractorAddress(
+                new Street('street'),
+                new PostalCode('postal'),
+                new City('city'),
+                new Country('GR')
+            )
+        );
+
+        $this->assertXmlStringEqualsXmlString(
+            <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<api>
+    <contractors>
+        <contractor>
+            <name>name</name>
+            <altname>name</altname>
+            <street>street</street>
+            <zip>postal</zip>
+            <city>city</city>
+            <country>GR</country>
+            <email>name@foo.bar</email>
+        </contractor>
+    </contractors>
+</api>
+XML,
+            $person->print(WfirmaMedia::api())->toString()
+        );
+        $this->assertEquals($person->print(WfirmaMedia::api()), $anotherPerson->print(WfirmaMedia::api()));
     }
 }


### PR DESCRIPTION
The EU uses `EL` as the code for Greece for VAT administration purposes, but the actual alpha-2 code for the country is `GR`. This may cause inconsistencies depending on whether a particular service (like wFirma) accepts one or the other. This will make sure that when printing Contractor data for the wFirma API, we use the actual alpha-2 code.