### PR TITLE
Differentiate exceptions in ViesIdentifierFactory

### DIFF
--- a/src/Vies/Contractor/Company/ValueAddedTax/ViesIdentifierFactory.php
+++ b/src/Vies/Contractor/Company/ValueAddedTax/ViesIdentifierFactory.php
@@ -4,13 +4,14 @@ declare(strict_types=1);
 namespace Landingi\BookkeepingBundle\Vies\Contractor\Company\ValueAddedTax;
 
 use DragonBe\Vies\Vies;
-use Exception;
 use Landingi\BookkeepingBundle\Bookkeeping\Contractor\Address\Country;
 use Landingi\BookkeepingBundle\Bookkeeping\Contractor\Company\ValueAddedTax\IdentifierFactory;
 use Landingi\BookkeepingBundle\Bookkeeping\Contractor\Company\ValueAddedTax\SimpleIdentifier;
 use Landingi\BookkeepingBundle\Bookkeeping\Contractor\Company\ValueAddedTax\ValidatedIdentifier;
 use Landingi\BookkeepingBundle\Bookkeeping\Contractor\Company\ValueAddedTaxIdentifier;
+use Landingi\BookkeepingBundle\Bookkeeping\Contractor\ContractorException;
 use Landingi\BookkeepingBundle\Vies\Contractor\InvalidViesIdentifierException;
+use Landingi\BookkeepingBundle\Vies\Exception\ViesServiceException;
 use Landingi\BookkeepingBundle\Vies\ViesException;
 
 final class ViesIdentifierFactory implements IdentifierFactory
@@ -24,6 +25,7 @@ final class ViesIdentifierFactory implements IdentifierFactory
 
     /**
      * @throws ViesException
+     * @throws InvalidViesIdentifierException
      */
     public function create(string $identifier, string $country): ValueAddedTaxIdentifier
     {
@@ -41,8 +43,12 @@ final class ViesIdentifierFactory implements IdentifierFactory
             }
 
             return new ValidatedIdentifier(new SimpleIdentifier($identifier), $country);
-        } catch (Exception $e) {
-            throw new ViesException('VIES external service exception: ' . $e->getMessage());
+        } catch (ContractorException $e) {
+            throw InvalidViesIdentifierException::validationFailed($identifier);
+        } catch (\DragonBe\Vies\ViesException $e) {
+            throw new ViesException($e->getMessage(), $e->getCode(), $e);
+        } catch (\DragonBe\Vies\ViesServiceException $e) {
+            throw new ViesServiceException($e->getMessage(), $e->getCode(), $e);
         }
     }
 }

--- a/src/Vies/Exception/ViesServiceException.php
+++ b/src/Vies/Exception/ViesServiceException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Landingi\BookkeepingBundle\Vies\Exception;
+
+use RuntimeException;
+
+final class ViesServiceException extends RuntimeException
+{
+}

--- a/tests/Integration/Vies/ViesValueAddedTaxIdentifierFactoryTest.php
+++ b/tests/Integration/Vies/ViesValueAddedTaxIdentifierFactoryTest.php
@@ -7,8 +7,11 @@ use DragonBe\Vies\Vies;
 use Landingi\BookkeepingBundle\Bookkeeping\Contractor\Company\ValueAddedTax\SimpleIdentifier;
 use Landingi\BookkeepingBundle\Bookkeeping\Contractor\Company\ValueAddedTax\ValidatedIdentifier;
 use Landingi\BookkeepingBundle\Integration\IntegrationTestCase;
+use Landingi\BookkeepingBundle\Unit\Fake\ThrowingVies;
 use Landingi\BookkeepingBundle\Vies\Contractor\Company\ValueAddedTax\ViesIdentifierFactory;
 use Landingi\BookkeepingBundle\Vies\Contractor\InvalidViesIdentifierException;
+use Landingi\BookkeepingBundle\Vies\Exception\ViesServiceException;
+use Landingi\BookkeepingBundle\Vies\ViesException;
 
 final class ViesValueAddedTaxIdentifierFactoryTest extends IntegrationTestCase
 {
@@ -19,7 +22,7 @@ final class ViesValueAddedTaxIdentifierFactoryTest extends IntegrationTestCase
 
         self::assertTrue($identifier instanceof ValidatedIdentifier);
         self::assertEquals('FR29480969591', $identifier->toString());
-        sleep(1);
+        sleep(1); // Sleeps added because of VIES API rate limit.
     }
 
     public function testItIsValidPolishIdentifier(): void
@@ -39,5 +42,21 @@ final class ViesValueAddedTaxIdentifierFactoryTest extends IntegrationTestCase
         $factory = new ViesIdentifierFactory(new Vies());
         $factory->create('333111222', 'DE');
         sleep(1);
+    }
+
+    public function testItThrowsWhenViesThrowsGenericException(): void
+    {
+        self::expectException(ViesException::class);
+
+        $factory = new ViesIdentifierFactory(ThrowingVies::viesException());
+        $factory->create('333111222', 'DE');
+    }
+
+    public function testItThrowsWhenViesThrowsServiceException(): void
+    {
+        self::expectException(ViesServiceException::class);
+
+        $factory = new ViesIdentifierFactory(ThrowingVies::serviceException());
+        $factory->create('333111222', 'DE');
     }
 }

--- a/tests/Integration/Vies/ViesValueAddedTaxIdentifierFactoryTest.php
+++ b/tests/Integration/Vies/ViesValueAddedTaxIdentifierFactoryTest.php
@@ -8,7 +8,7 @@ use Landingi\BookkeepingBundle\Bookkeeping\Contractor\Company\ValueAddedTax\Simp
 use Landingi\BookkeepingBundle\Bookkeeping\Contractor\Company\ValueAddedTax\ValidatedIdentifier;
 use Landingi\BookkeepingBundle\Integration\IntegrationTestCase;
 use Landingi\BookkeepingBundle\Vies\Contractor\Company\ValueAddedTax\ViesIdentifierFactory;
-use Landingi\BookkeepingBundle\Vies\ViesException;
+use Landingi\BookkeepingBundle\Vies\Contractor\InvalidViesIdentifierException;
 
 final class ViesValueAddedTaxIdentifierFactoryTest extends IntegrationTestCase
 {
@@ -34,7 +34,7 @@ final class ViesValueAddedTaxIdentifierFactoryTest extends IntegrationTestCase
 
     public function testItIsInvalidIdentifier(): void
     {
-        self::expectException(ViesException::class);
+        self::expectException(InvalidViesIdentifierException::class);
 
         $factory = new ViesIdentifierFactory(new Vies());
         $factory->create('333111222', 'DE');

--- a/tests/Unit/Fake/ThrowingVies.php
+++ b/tests/Unit/Fake/ThrowingVies.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Landingi\BookkeepingBundle\Unit\Fake;
+
+use DragonBe\Vies\CheckVatResponse;
+use DragonBe\Vies\Vies;
+use DragonBe\Vies\ViesException;
+use DragonBe\Vies\ViesServiceException;
+use Throwable;
+
+final class ThrowingVies extends Vies
+{
+    /**
+     * @var class-string<Throwable>
+     */
+    private string $exceptionClass;
+
+    public static function serviceException(): self
+    {
+        return new self(ViesServiceException::class);
+    }
+
+    public static function viesException(): self
+    {
+        return new self(ViesException::class);
+    }
+
+    /**
+     * @param class-string<Throwable> $exceptionClass
+     */
+    private function __construct(string $exceptionClass)
+    {
+        $this->exceptionClass = $exceptionClass;
+    }
+
+    public function validateVat(
+        $countryCode,
+        $vatNumber,
+        string $requesterCountryCode = '',
+        string $requesterVatNumber = '',
+        string $traderName = '',
+        string $traderCompanyType = '',
+        string $traderStreet = '',
+        string $traderPostcode = '',
+        string $traderCity = ''
+    ): CheckVatResponse {
+        throw new $this->exceptionClass();
+    }
+}


### PR DESCRIPTION
This adds more exceptions thrown by the `ViesIdentifierFactory` class to make sure we can differentiate between invalid VAT IDs, the VIES service being unavailable, and an invalid country being passed to the service.