### PR TITLE
Update Luxemburg tax rate

### DIFF
--- a/src/Bookkeeping/Invoice/InvoiceItem/Price.php
+++ b/src/Bookkeeping/Invoice/InvoiceItem/Price.php
@@ -11,15 +11,9 @@ final class Price
 
     /**
      * Provide $price in cents. The minimal value is 1 (0.01).
-     *
-     * @throws InvoiceItemException
      */
     public function __construct(int $price)
     {
-        if ($price <= 0) {
-            throw new InvoiceItemException('Price must be a greater that zero');
-        }
-
         $this->price = $price;
     }
 

--- a/src/Memory/MemoryValueAddedTaxStorage.php
+++ b/src/Memory/MemoryValueAddedTaxStorage.php
@@ -29,7 +29,7 @@ final class MemoryValueAddedTaxStorage implements ValueAddedTaxStorage
         'IT' => 22,
         'LT' => 21,
         'LV' => 21,
-        'LU' => 17,
+        'LU' => 16,
         'MT' => 18,
         'NL' => 21,
         'PL' => 23,

--- a/src/Wfirma/Invoice/Factory/InvoiceFactory.php
+++ b/src/Wfirma/Invoice/Factory/InvoiceFactory.php
@@ -39,7 +39,7 @@ final class InvoiceFactory
     {
         $invoiceItems = [];
 
-        foreach ($items as $key => $item) {
+        foreach ($items as $item) {
             $invoiceItems[] = new WfirmaInvoiceItem(
                 new Invoice\InvoiceItem\Name($item['invoicecontent']['name']),
                 new Invoice\InvoiceItem\Price((int) ($item['invoicecontent']['price'] * 100)), // In-currency

--- a/tests/Unit/Bookkeeping/Invoice/InvoiceItem/PriceTest.php
+++ b/tests/Unit/Bookkeeping/Invoice/InvoiceItem/PriceTest.php
@@ -21,16 +21,4 @@ final class PriceTest extends TestCase
         self::assertEquals('10', (string) $price);
         self::assertEquals(10, $price->toFloat());
     }
-
-    public function testItIsNotEmptyString(): void
-    {
-        $this->expectException(InvoiceItemException::class);
-        new Price(0);
-
-        $this->expectException(InvoiceItemException::class);
-        new Price(-1);
-
-        $this->expectException(InvoiceItemException::class);
-        new Price(-1000);
-    }
 }

--- a/tests/Unit/Memory/MemoryValueAddedTaxStorageTest.php
+++ b/tests/Unit/Memory/MemoryValueAddedTaxStorageTest.php
@@ -57,7 +57,7 @@ final class MemoryValueAddedTaxStorageTest extends TestCase
         yield ['IT', 22];
         yield ['LT', 21];
         yield ['LV', 21];
-        yield ['LU', 17];
+        yield ['LU', 16];
         yield ['MT', 18];
         yield ['NL', 21];
         yield ['PL', 23];


### PR DESCRIPTION
Also fixes bug, that InvoiceItem must have `> 0` price. It's legal for invoice items to have negative price (e.g. discount)