### PR TITLE
Add disposalDate property in InvoiceSummary items

### DIFF
--- a/src/Bookkeeping/InvoiceSummary.php
+++ b/src/Bookkeeping/InvoiceSummary.php
@@ -21,6 +21,7 @@ final class InvoiceSummary
     private DateTimeImmutable $createdAt;
     private DateTimeImmutable $modifiedAt;
     private DateTimeImmutable $paidAt;
+    private DateTimeImmutable $disposalDate;
     private InvoicePaymentMethod $paymentMethod;
 
     public function __construct(
@@ -32,6 +33,7 @@ final class InvoiceSummary
         DateTimeImmutable $createdAt,
         DateTimeImmutable $modifiedAt,
         DateTimeImmutable $paidAt,
+        DateTimeImmutable $disposalDate,
         InvoicePaymentMethod $paymentMethod
     ) {
         $this->identifier = $identifier;
@@ -42,6 +44,7 @@ final class InvoiceSummary
         $this->createdAt = $createdAt;
         $this->modifiedAt = $modifiedAt;
         $this->paidAt = $paidAt;
+        $this->disposalDate = $disposalDate;
         $this->paymentMethod = $paymentMethod;
     }
 
@@ -83,6 +86,11 @@ final class InvoiceSummary
     public function getPaidAt(): DateTimeImmutable
     {
         return $this->paidAt;
+    }
+
+    public function getDisposalDate(): DateTimeImmutable
+    {
+        return $this->disposalDate;
     }
 
     public function getPaymentMethod(): InvoicePaymentMethod

--- a/src/Wfirma/Invoice/Factory/InvoiceSummaryFactory.php
+++ b/src/Wfirma/Invoice/Factory/InvoiceSummaryFactory.php
@@ -26,6 +26,7 @@ final class InvoiceSummaryFactory
             new DateTimeImmutable($data['created']),
             new DateTimeImmutable($data['modified']),
             new DateTimeImmutable($data['paymentdate']),
+            new DateTimeImmutable($data['disposaldate']),
             new InvoicePaymentMethod($data['paymentmethod'])
         );
     }

--- a/tests/Unit/Bookkeeping/InvoiceSummaryTest.php
+++ b/tests/Unit/Bookkeeping/InvoiceSummaryTest.php
@@ -26,7 +26,7 @@ class InvoiceSummaryTest extends TestCase
             new \DateTimeImmutable('2023-05-10'),
             new \DateTimeImmutable('2023-05-11'),
             new \DateTimeImmutable('2023-05-12'),
-            new \DateTimeImmutable('2023-05-13'),
+            new \DateTimeImmutable('2023-05-14'),
             new InvoicePaymentMethod('transfer')
         );
         $this->assertEquals('123', (string) $summary->getIdentifier());
@@ -37,7 +37,7 @@ class InvoiceSummaryTest extends TestCase
         $this->assertEquals('2023-05-10', $summary->getCreatedAt()->format('Y-m-d'));
         $this->assertEquals('2023-05-11', $summary->getModifiedAt()->format('Y-m-d'));
         $this->assertEquals('2023-05-12', $summary->getPaidAt()->format('Y-m-d'));
-        $this->assertEquals('2023-05-13', $summary->getDisposalDate()->format('Y-m-d'));
+        $this->assertEquals('2023-05-14', $summary->getDisposalDate()->format('Y-m-d'));
         $this->assertTrue($summary->getPaymentMethod()->isTransfer());
     }
 }

--- a/tests/Unit/Bookkeeping/InvoiceSummaryTest.php
+++ b/tests/Unit/Bookkeeping/InvoiceSummaryTest.php
@@ -26,7 +26,7 @@ class InvoiceSummaryTest extends TestCase
             new \DateTimeImmutable('2023-05-10'),
             new \DateTimeImmutable('2023-05-11'),
             new \DateTimeImmutable('2023-05-12'),
-            new \DateTimeImmutable('2023-05-15'),
+            new \DateTimeImmutable('2023-05-16'),
             new InvoicePaymentMethod('transfer')
         );
         $this->assertEquals('123', (string) $summary->getIdentifier());
@@ -37,7 +37,7 @@ class InvoiceSummaryTest extends TestCase
         $this->assertEquals('2023-05-10', $summary->getCreatedAt()->format('Y-m-d'));
         $this->assertEquals('2023-05-11', $summary->getModifiedAt()->format('Y-m-d'));
         $this->assertEquals('2023-05-12', $summary->getPaidAt()->format('Y-m-d'));
-        $this->assertEquals('2023-05-15', $summary->getDisposalDate()->format('Y-m-d'));
+        $this->assertEquals('2023-05-16', $summary->getDisposalDate()->format('Y-m-d'));
         $this->assertTrue($summary->getPaymentMethod()->isTransfer());
     }
 }

--- a/tests/Unit/Bookkeeping/InvoiceSummaryTest.php
+++ b/tests/Unit/Bookkeeping/InvoiceSummaryTest.php
@@ -26,6 +26,7 @@ class InvoiceSummaryTest extends TestCase
             new \DateTimeImmutable('2023-05-10'),
             new \DateTimeImmutable('2023-05-11'),
             new \DateTimeImmutable('2023-05-12'),
+            new \DateTimeImmutable('2023-05-13'),
             new InvoicePaymentMethod('transfer')
         );
         $this->assertEquals('123', (string) $summary->getIdentifier());
@@ -36,6 +37,7 @@ class InvoiceSummaryTest extends TestCase
         $this->assertEquals('2023-05-10', $summary->getCreatedAt()->format('Y-m-d'));
         $this->assertEquals('2023-05-11', $summary->getModifiedAt()->format('Y-m-d'));
         $this->assertEquals('2023-05-12', $summary->getPaidAt()->format('Y-m-d'));
+        $this->assertEquals('2023-05-13', $summary->getDisposalDate()->format('Y-m-d'));
         $this->assertTrue($summary->getPaymentMethod()->isTransfer());
     }
 }

--- a/tests/Unit/Bookkeeping/InvoiceSummaryTest.php
+++ b/tests/Unit/Bookkeeping/InvoiceSummaryTest.php
@@ -26,7 +26,7 @@ class InvoiceSummaryTest extends TestCase
             new \DateTimeImmutable('2023-05-10'),
             new \DateTimeImmutable('2023-05-11'),
             new \DateTimeImmutable('2023-05-12'),
-            new \DateTimeImmutable('2023-05-14'),
+            new \DateTimeImmutable('2023-05-15'),
             new InvoicePaymentMethod('transfer')
         );
         $this->assertEquals('123', (string) $summary->getIdentifier());
@@ -37,7 +37,7 @@ class InvoiceSummaryTest extends TestCase
         $this->assertEquals('2023-05-10', $summary->getCreatedAt()->format('Y-m-d'));
         $this->assertEquals('2023-05-11', $summary->getModifiedAt()->format('Y-m-d'));
         $this->assertEquals('2023-05-12', $summary->getPaidAt()->format('Y-m-d'));
-        $this->assertEquals('2023-05-14', $summary->getDisposalDate()->format('Y-m-d'));
+        $this->assertEquals('2023-05-15', $summary->getDisposalDate()->format('Y-m-d'));
         $this->assertTrue($summary->getPaymentMethod()->isTransfer());
     }
 }


### PR DESCRIPTION
DisposalDate property is required in edge-case when the admin wants to add an invoice to the application but paid_date should be equal to Disposal-date instead of Paid-date.