### PR TITLE
Round invoice prices before casting them to integer

### DIFF
--- a/src/Wfirma/Invoice/Factory/InvoiceFactory.php
+++ b/src/Wfirma/Invoice/Factory/InvoiceFactory.php
@@ -23,8 +23,8 @@ final class InvoiceFactory
             new Invoice\InvoiceSeries(new InvoiceSeriesIdentifier($data['series']['id'])),
             new Invoice\InvoiceDescription($data['description']),
             new Invoice\InvoiceFullNumber($data['fullnumber']),
-            new Invoice\InvoiceTotalValue((int) ($data['total'] * 100)), // This is in-currency
-            new Invoice\InvoiceNetPlnValue((int) ($data['netto'] * 100)),
+            new Invoice\InvoiceTotalValue((int) round($data['total'] * 100)), // This is in-currency
+            new Invoice\InvoiceNetPlnValue((int) round($data['netto'] * 100)),
             new WfirmaInvoiceItemCollection($this->getInvoiceItems($data['invoicecontents'])),
             $contractor,
             new Currency($data['currency']),
@@ -42,7 +42,7 @@ final class InvoiceFactory
         foreach ($items as $item) {
             $invoiceItems[] = new WfirmaInvoiceItem(
                 new Invoice\InvoiceItem\Name($item['invoicecontent']['name']),
-                new Invoice\InvoiceItem\Price((int) ($item['invoicecontent']['price'] * 100)), // In-currency
+                new Invoice\InvoiceItem\Price((int) round($item['invoicecontent']['price'] * 100)), // In-currency
                 new WfirmaValueAddedTax(
                     (string) $item['invoicecontent']['vat_code']['id'],
                     new Invoice\InvoiceItem\ValueAddedTax(0)

--- a/tests/Unit/Wfirma/Invoice/Factory/InvoiceFactoryTest.php
+++ b/tests/Unit/Wfirma/Invoice/Factory/InvoiceFactoryTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Landingi\BookkeepingBundle\Unit\Wfirma\Invoice\Factory;
+
+use Landingi\BookkeepingBundle\Memory\Contractor\Company\ValueAddedTax\MemoryIdentifierFactory;
+use Landingi\BookkeepingBundle\Wfirma\Contractor\Factory\ContractorFactory;
+use Landingi\BookkeepingBundle\Wfirma\Invoice\Factory\InvoiceFactory;
+use PHPUnit\Framework\TestCase;
+
+class InvoiceFactoryTest extends TestCase
+{
+    private InvoiceFactory $sut;
+    private ContractorFactory $contractorFactory;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->sut = new InvoiceFactory();
+        $this->contractorFactory = new ContractorFactory(new MemoryIdentifierFactory());
+    }
+
+    /**
+     * @dataProvider provideInvoiceData
+     * @covers \Landingi\BookkeepingBundle\Bookkeeping\Invoice::getTotalValue()
+     */
+    public function testCreatesInvoiceFromApiDataWithProperlyRoundedAmounts(
+        array $invoiceData,
+        array $contractorData
+    ): void {
+        $invoice = $this->sut->getInvoiceFromApiData(
+            $invoiceData,
+            $this->contractorFactory->getContractor($contractorData)
+        );
+
+        // Total value equals amount returned from API, test integer rounding of floating point numbers
+        $this->assertEquals((float) $invoiceData['total'], $invoice->getTotalValue()->toFloat());
+
+        // Total net equals sum of items
+        $this->assertEquals($invoice->getNetPlnValue()->toFloat(), $invoice->getMoneyValue());
+    }
+
+    public function provideInvoiceData(): \Iterator
+    {
+        yield 'Invoice with float total value' => [
+            [
+                'id' => '1',
+                'series' => [
+                    'id' => 1,
+                ],
+                'description' => 'Test',
+                'fullnumber' => '1/2021',
+                'total' => 8.12,
+                'netto' => 6.60,
+                'invoicecontents' => [
+                    [
+                        'invoicecontent' => [
+                            'name' => 'Test',
+                            'price' => 6.60,
+                            'vat_code' => [
+                                'id' => '1',
+                            ],
+                            'count' => 1,
+                        ],
+                    ],
+                ],
+                'currency' => 'PLN',
+                'date' => '2021-01-01',
+                'paymentdate' => '2021-01-01',
+                'disposaldate' => '2021-01-01',
+                'translation_language' => 0,
+            ],
+            [
+                'id' => '1',
+                'name' => 'Test',
+                'email' => 'test@example.com',
+                'street' => 'Test',
+                'zip' => '00-000',
+                'city' => 'Test',
+                'country' => 'PL',
+            ]
+        ];
+    }
+}


### PR DESCRIPTION
If some of the money amounts in an invoice are floats, multiplying them by 100 and then casting to int may cause unintended floating-point number related side effects:
![obraz](https://github.com/landingi/bookkeeping-bundle/assets/4033768/3f936027-0bad-43d8-a75c-4b0421ad524a)


This makes sure the multiplication-resulting float number is first rounded to an integer-ish value, then casted to an actual integer type, which fixes this issue.