### PR TITLE
[PLT-2058]Refactor VAT validation logic in ViesIdentifierFactory

### DIFF
--- a/src/Vies/Contractor/Company/ValueAddedTax/ViesIdentifierFactory.php
+++ b/src/Vies/Contractor/Company/ValueAddedTax/ViesIdentifierFactory.php
@@ -52,7 +52,7 @@ final class ViesIdentifierFactory implements IdentifierFactory
         if ($country->isEuropeanUnion()) {
             $validation = $this->viesClient->validateVat($country->toString(), $identifier);
 
-            if (self::CONCURRENT_REQUESTS_ERROR_NAME === $validation['userError']) {
+            if (isset($validation['userError']) && self::CONCURRENT_REQUESTS_ERROR_NAME === $validation['userError']) {
                 throw ConcurrentRequestViesIdentifierException::validationBlockedByConcurrentRequests($identifier);
             }
 

--- a/src/Vies/Contractor/Company/ValueAddedTax/ViesIdentifierFactory.php
+++ b/src/Vies/Contractor/Company/ValueAddedTax/ViesIdentifierFactory.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace Landingi\BookkeepingBundle\Vies\Contractor\Company\ValueAddedTax;
 
-use Exception;
 use Landingi\BookkeepingBundle\Bookkeeping\Contractor\Address\Country;
 use Landingi\BookkeepingBundle\Bookkeeping\Contractor\Company\ValueAddedTax\IdentifierFactory;
 use Landingi\BookkeepingBundle\Bookkeeping\Contractor\Company\ValueAddedTax\SimpleIdentifier;
@@ -11,10 +10,12 @@ use Landingi\BookkeepingBundle\Bookkeeping\Contractor\Company\ValueAddedTax\Vali
 use Landingi\BookkeepingBundle\Bookkeeping\Contractor\Company\ValueAddedTaxIdentifier;
 use Landingi\BookkeepingBundle\Bookkeeping\Contractor\ContractorException;
 use Landingi\BookkeepingBundle\Vies\Client\ViesClient;
+use Landingi\BookkeepingBundle\Vies\Contractor\ConcurrentRequestViesIdentifierException;
 use Landingi\BookkeepingBundle\Vies\Contractor\InvalidViesIdentifierException;
 
 final class ViesIdentifierFactory implements IdentifierFactory
 {
+    private const CONCURRENT_REQUESTS_ERROR_NAME = 'MS_MAX_CONCURRENT_REQ';
     private ViesClient $viesClient;
 
     public function __construct(ViesClient $viesClient)
@@ -23,7 +24,7 @@ final class ViesIdentifierFactory implements IdentifierFactory
     }
 
     /**
-     * @throws InvalidViesIdentifierException
+     * @throws InvalidViesIdentifierException|ConcurrentRequestViesIdentifierException
      */
     public function create(string $identifier, string $country): ValueAddedTaxIdentifier
     {
@@ -32,20 +33,28 @@ final class ViesIdentifierFactory implements IdentifierFactory
 
             $this->validateVat($identifier, $country);
 
-            if ($country->isPoland()) {
+            if ($country->isPoland() || !$country->isEuropeanUnion()) {
                 return new SimpleIdentifier($identifier);
             }
 
             return new ValidatedIdentifier(new SimpleIdentifier($identifier), $country);
-        } catch (ContractorException|Exception $e) {
+        } catch (ContractorException $e) {
             throw InvalidViesIdentifierException::validationFailed($identifier);
         }
     }
 
+    /**
+     * @throws ConcurrentRequestViesIdentifierException
+     * @throws InvalidViesIdentifierException
+     */
     private function validateVat(string $identifier, Country $country): void
     {
         if ($country->isEuropeanUnion()) {
             $validation = $this->viesClient->validateVat($country->toString(), $identifier);
+
+            if (self::CONCURRENT_REQUESTS_ERROR_NAME === $validation['userError']) {
+                throw ConcurrentRequestViesIdentifierException::validationBlockedByConcurrentRequests($identifier);
+            }
 
             if (false === $validation['isValid']) {
                 throw InvalidViesIdentifierException::validationFailed($identifier);

--- a/src/Vies/Contractor/ConcurrentRequestViesIdentifierException.php
+++ b/src/Vies/Contractor/ConcurrentRequestViesIdentifierException.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types=1);
+
+namespace Landingi\BookkeepingBundle\Vies\Contractor;
+
+use Exception;
+
+final class ConcurrentRequestViesIdentifierException extends Exception
+{
+    public static function validationBlockedByConcurrentRequests(string $identifier): self
+    {
+        return new self(sprintf('Validation for identifier %s was blocked', $identifier));
+    }
+}

--- a/tests/Integration/Vies/ViesValueAddedTaxIdentifierFactoryTest.php
+++ b/tests/Integration/Vies/ViesValueAddedTaxIdentifierFactoryTest.php
@@ -26,7 +26,7 @@ final class ViesValueAddedTaxIdentifierFactoryTest extends IntegrationTestCase
         $factory = new ViesIdentifierFactory(new ViesClient());
         $identifier = $factory->create('105454931', 'GB');
 
-        self::assertTrue($identifier instanceof ValidatedIdentifier);
+        self::assertTrue($identifier instanceof SimpleIdentifier);
         self::assertEquals('105454931', $identifier->toString());
     }
 

--- a/tests/Integration/Vies/ViesValueAddedTaxIdentifierFactoryTest.php
+++ b/tests/Integration/Vies/ViesValueAddedTaxIdentifierFactoryTest.php
@@ -6,22 +6,28 @@ namespace Landingi\BookkeepingBundle\Integration\Vies;
 use Landingi\BookkeepingBundle\Bookkeeping\Contractor\Company\ValueAddedTax\SimpleIdentifier;
 use Landingi\BookkeepingBundle\Bookkeeping\Contractor\Company\ValueAddedTax\ValidatedIdentifier;
 use Landingi\BookkeepingBundle\Integration\IntegrationTestCase;
-use Landingi\BookkeepingBundle\Unit\Fake\ThrowingVies;
 use Landingi\BookkeepingBundle\Vies\Client\ViesClient;
 use Landingi\BookkeepingBundle\Vies\Contractor\Company\ValueAddedTax\ViesIdentifierFactory;
 use Landingi\BookkeepingBundle\Vies\Contractor\InvalidViesIdentifierException;
-use Landingi\BookkeepingBundle\Vies\Exception\ViesServiceException;
-use Landingi\BookkeepingBundle\Vies\ViesException;
 
 final class ViesValueAddedTaxIdentifierFactoryTest extends IntegrationTestCase
 {
     public function testItIsValidIdentifier(): void
     {
         $factory = new ViesIdentifierFactory(new ViesClient());
-        $identifier = $factory->create('29480969591', 'FR');
+        $identifier = $factory->create('ESB40582447', 'ES');
 
         self::assertTrue($identifier instanceof ValidatedIdentifier);
-        self::assertEquals('FR29480969591', $identifier->toString());
+        self::assertEquals('ESB40582447', $identifier->toString());
+    }
+
+    public function testItIsValidIdentifierForCountryOutsideEu(): void
+    {
+        $factory = new ViesIdentifierFactory(new ViesClient());
+        $identifier = $factory->create('GB105454931', 'GB');
+
+        self::assertTrue($identifier instanceof ValidatedIdentifier);
+        self::assertEquals('105454931', $identifier->toString());
     }
 
     public function testItIsValidPolishIdentifier(): void

--- a/tests/Integration/Vies/ViesValueAddedTaxIdentifierFactoryTest.php
+++ b/tests/Integration/Vies/ViesValueAddedTaxIdentifierFactoryTest.php
@@ -15,7 +15,7 @@ final class ViesValueAddedTaxIdentifierFactoryTest extends IntegrationTestCase
     public function testItIsValidIdentifier(): void
     {
         $factory = new ViesIdentifierFactory(new ViesClient());
-        $identifier = $factory->create('ESB40582447', 'ES');
+        $identifier = $factory->create('B40582447', 'ES');
 
         self::assertTrue($identifier instanceof ValidatedIdentifier);
         self::assertEquals('ESB40582447', $identifier->toString());
@@ -24,7 +24,7 @@ final class ViesValueAddedTaxIdentifierFactoryTest extends IntegrationTestCase
     public function testItIsValidIdentifierForCountryOutsideEu(): void
     {
         $factory = new ViesIdentifierFactory(new ViesClient());
-        $identifier = $factory->create('GB105454931', 'GB');
+        $identifier = $factory->create('105454931', 'GB');
 
         self::assertTrue($identifier instanceof ValidatedIdentifier);
         self::assertEquals('105454931', $identifier->toString());


### PR DESCRIPTION
This pull request enhances error handling for VAT identifier validation in the VIES integration by introducing a dedicated exception for concurrent request errors and updating the validation logic accordingly. The main goal is to provide clearer feedback when VIES validation is blocked due to too many concurrent requests.