### PR TITLE
[PLT-2067]Handle non-EU countries in identifier creation

### DIFF
--- a/src/Memory/Contractor/Company/ValueAddedTax/MemoryIdentifierFactory.php
+++ b/src/Memory/Contractor/Company/ValueAddedTax/MemoryIdentifierFactory.php
@@ -22,7 +22,7 @@ final class MemoryIdentifierFactory implements IdentifierFactory
 
         $country = new Country($country);
 
-        if ($country->isPoland()) {
+        if ($country->isPoland() || !$country->isEuropeanUnion()) {
             return new SimpleIdentifier($identifier);
         }
 

--- a/tests/Integration/Wfirma/Invoice/CreateInvoiceTest.php
+++ b/tests/Integration/Wfirma/Invoice/CreateInvoiceTest.php
@@ -345,7 +345,7 @@ XML;
             <country>GB</country>
             <email>test@landingi.com</email>
             <tax_id_type>custom</tax_id_type>
-            <nip>GB550844926014</nip>
+            <nip>550844926014</nip>
         </contractor>
     </contractors>
 </api>
@@ -457,7 +457,7 @@ XML;
             <country>US</country>
             <email>test@landingi.com</email>
             <tax_id_type>custom</tax_id_type>
-            <nip>US333444555</nip>
+            <nip>333444555</nip>
         </contractor>
     </contractors>
 </api>


### PR DESCRIPTION
This pull request updates the logic for creating VAT identifiers in `MemoryIdentifierFactory`. Now, companies from non-EU countries will receive a `SimpleIdentifier`, aligning the behavior with Polish companies.
